### PR TITLE
BREAKING CHANGE fix(framework)!: Add default render prop to useToast …

### DIFF
--- a/framework/lib/components/toast/index.ts
+++ b/framework/lib/components/toast/index.ts
@@ -1,6 +1,3 @@
-export {
-  useToast,
-} from '@chakra-ui/react'
-
 export * from './toast'
 export * from './types'
+export * from './use-toast'

--- a/framework/lib/components/toast/types.ts
+++ b/framework/lib/components/toast/types.ts
@@ -1,3 +1,4 @@
+import { UseToastOptions as UseChakraToastOptions } from '@chakra-ui/react'
 import { AlertProps, AlertVariants } from '../alert'
 
 export interface ToastProps extends AlertProps {
@@ -5,4 +6,10 @@ export interface ToastProps extends AlertProps {
   variant?: AlertVariants
   description?: string
   onClose?: () => void
+}
+
+export interface UseToastOptions extends UseChakraToastOptions {
+  variant?: AlertVariants
+  title?: string
+  description?: string
 }

--- a/framework/lib/components/toast/use-toast.tsx
+++ b/framework/lib/components/toast/use-toast.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { useToast as useChakraToast } from '@chakra-ui/react'
+import { Toast } from './toast'
+import { UseToastOptions } from './types'
+
+export const useToast = (defaultOpts: UseToastOptions = {}) => {
+  const toast = useChakraToast(defaultOpts)
+
+  return (opts: UseToastOptions = {}) => toast({
+    render: ({ onClose }) => {
+      const { variant = 'success', title = 'Success', description = '' } = opts
+
+      return (
+        <Toast
+          variant={ variant }
+          title={ title }
+          description={ description }
+          onClose={ onClose }
+        />
+      )
+    },
+    position: 'top',
+    ...opts,
+  })
+}

--- a/framework/sandbox/docs/pages/toast-page/index.tsx
+++ b/framework/sandbox/docs/pages/toast-page/index.tsx
@@ -4,6 +4,7 @@ import {
   Code,
   Divider,
   HStack,
+  P,
   Stack,
   Text,
   Toast,
@@ -59,15 +60,9 @@ const ToastPage = () => {
           <Button
             variant="success"
             onClick={ () => toast({
-              position: 'top-right',
-              render: ({ onClose }) => (
-                <Toast
-                  variant="success"
-                  title="Saved"
-                  description="Your setting have been saved, you will need to reload the page before the changes take effect."
-                  onClose={ onClose }
-                />
-              ),
+              variant: 'success',
+              title: 'Saved',
+              description: 'Your setting have been saved, you will need to reload the page before the changes take effect.',
             })
           }
           >
@@ -96,16 +91,23 @@ const ToastPage = () => {
 `const toast = useToast()
 toast({
   position: 'top-right',
-  render: ({ onClose }) => (
-    <Toast
-      variant="error"
-      title="Error  "
-      description="Please save you changes before exiting"
-      onClose={ onClose }
-    />
-  ),
+  variant:"error"
+  title:"Error  "
+  description:"Please save you changes before exiting"
+  onClose={ onClose }
 })` }
         </Code>
+        <P>
+          The default values are: <br />
+        </P>
+        <Code w="max-content" whiteSpace="pre" display="block">
+          variant: 'success' <br />
+          title: 'Success' <br />
+          position: 'top' <br />
+        </Code>
+        <P>
+          One can also render a custom element using the <b>render</b> prop.
+        </P>
         <Text>Example: </Text>
         <Code w="max-content" display="block" whiteSpace="pre">{
 `const toast = useToast()


### PR DESCRIPTION
…hook

After much heated discussion regarding the syntactic use of the useToast hook, Sebastian in the end decided to favor the blue team by adding their much
request syntax sugar. This keeps the old way of
writing the toast, but now if one does not specify the render option then it will render the default
ui toast by default and pass down the title, variant and description from the other options.

This will only break if one did not specify a render prop previousely, which everyone did in the codebase, except for one person... looking at you Oles