### PR TITLE
fix(framework): overflow group responsive issue

### DIFF
--- a/framework/lib/components/overflow-group/overflow-group.tsx
+++ b/framework/lib/components/overflow-group/overflow-group.tsx
@@ -58,6 +58,10 @@ export const OverflowGroup = ({
     initMax,
   ])
 
+  useEffect(() => {
+    isLocked.current = false
+  }, [ rectDependency.clientHeight, rectDependency.clientWidth ])
+
   const handleResize = () => {
     setTimeout(() => {
       isLocked.current = false


### PR DESCRIPTION
When scaling up the isLocked.current ref was set to true when it should reset if the container dimensions change This is fixed by adding another useEffect.

Before:

https://user-images.githubusercontent.com/90923099/220159695-20887124-cdbf-430f-9331-78e69456bf63.mov

After:

https://user-images.githubusercontent.com/90923099/220159721-3d261e07-fe04-418b-b78d-bd87c6e21ae2.mov

