### PR TITLE
fix(framework): make label prop optional on field

### DIFF
--- a/framework/lib/components/form/types.ts
+++ b/framework/lib/components/form/types.ts
@@ -23,7 +23,7 @@ export type SetValueOptionsType = Maybe<SetValueConfig>
 
 export type FieldProps = {
   name: string
-  label: string
+  label?: string
   direction?: StackDirection
   isRequired?: boolean
   isSelect?: boolean

--- a/framework/sandbox/docs/pages/field-page/index.tsx
+++ b/framework/sandbox/docs/pages/field-page/index.tsx
@@ -44,7 +44,8 @@ const FieldPage = () => (
       </Text>
       <Text>
         <strong>label </strong>- descriptive text that appears next to, or on
-        top of the field, required for accessibility
+        top of the field, for accessibility.
+        If no visible label is defined then an <b>aria-label</b> should be specified
       </Text>
       <Text>
         <strong>validate</strong>- Custom validation specific to field, check


### PR DESCRIPTION
In some cases one wants to render an input element without the need of a visible label, that might
not be apart of the sketches. The types should reflect this