### PR TITLE
fix(framework): access to form context api via ref

### DIFF
--- a/framework/lib/components/form/form.tsx
+++ b/framework/lib/components/form/form.tsx
@@ -1,16 +1,17 @@
-import React, { useEffect, useRef } from 'react'
+import React, { forwardRef, useEffect, useImperativeHandle, useRef } from 'react'
 import {
   DeepPartial,
   FieldValues,
   FormProvider,
   Resolver,
+  UseFormReturn,
   useForm,
 } from 'react-hook-form'
-import { equals } from 'ramda'
+import { always, equals } from 'ramda'
 import { FormProps } from './types'
 import { trimFormValues } from './trim-form-values'
 
-export function Form<FormValues extends FieldValues> ({
+export const Form = forwardRef(<FormValues extends FieldValues>({
   initialValues,
   onSubmit,
   children,
@@ -20,7 +21,7 @@ export function Form<FormValues extends FieldValues> ({
   enableReinitialize = false,
   shouldTrim = true,
   ...rest
-}: FormProps<FormValues>) {
+}: FormProps<FormValues>, ref: React.Ref<UseFormReturn<FormValues>>) => {
   const customResolver: Resolver<FormValues, any> = (
     values,
     _context,
@@ -37,6 +38,8 @@ export function Form<FormValues extends FieldValues> ({
       resolver: validate ? customResolver : undefined,
       ...formSettings,
     })
+
+  useImperativeHandle(ref, always(newMethods), [])
 
   if (enableReinitialize) {
     const initalValuesImage = useRef({})
@@ -72,4 +75,4 @@ export function Form<FormValues extends FieldValues> ({
       </form>
     </FormProvider>
   )
-}
+})

--- a/framework/lib/components/form/types.ts
+++ b/framework/lib/components/form/types.ts
@@ -5,12 +5,14 @@ import {
   FieldErrorsImpl,
   FieldValues,
   Merge,
+  UseFormReturn as RHFUseFormReturn,
   RegisterOptions,
   SetValueConfig,
   UseFormProps,
-  UseFormReturn,
 } from 'react-hook-form'
 import { StackDirection } from '@chakra-ui/react'
+
+export type UseFormReturn<T extends FieldValues> = RHFUseFormReturn<T>
 
 type Maybe<T> = T | undefined
 

--- a/framework/sandbox/docs/pages/form-page/index.tsx
+++ b/framework/sandbox/docs/pages/form-page/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import {
   Blockquote,
   Button,
@@ -6,11 +6,13 @@ import {
   Divider,
   Form,
   H2,
+  H3,
   HStack,
   Link,
   P,
   Stack,
   TextField,
+  UseFormReturn,
   VStack,
 } from '../../../../lib'
 import { Page } from '../../components'
@@ -25,39 +27,47 @@ const validation = (values: any) => {
   return errors
 }
 
-const FormPage = () => (
-  <Page
-    title="Form"
-    subtitle={ (
-      <>
-        <Blockquote>
-          The Form Component is an abstraction of react-hook-form,
-        </Blockquote>
-        <P>
-          It's main purpose is to initialize a form with the right state, and
-          pass down the context to it's children to be used with our field
-          components.
-        </P>
-      </>
+const FormPage = () => {
+  const initialValues = { firstName: '' }
+  const formMethods = useRef<UseFormReturn<typeof initialValues>>(null)
+  const getNewName = () => {
+    if (!formMethods.current) return
+    formMethods.current.reset({ firstName: Math.random().toString(36) })
+  }
+
+  return (
+    <Page
+      title="Form"
+      subtitle={ (
+        <>
+          <Blockquote>
+            The Form Component is an abstraction of react-hook-form,
+          </Blockquote>
+          <P>
+            It's main purpose is to initialize a form with the right state, and
+            pass down the context to it's children to be used with our field
+            components.
+          </P>
+        </>
     ) }
-  >
-    <Stack spacing={ 4 }>
-      <H2>
-        Our forms are built on{ ' ' }
-        <Link
-          color="blue.600"
-          _hover={ { textDecoration: 'underline' } }
-          href="https://react-hook-form.com/api"
-          isExternal={ true }
-        >
-          React Hook Form
-        </Link>
-      </H2>
-      <P>
-        Mediatool uses one <strong>{ '<Form />' }</strong> Component{ ' ' }
-      </P>
-      <Code w="max-content" display="block" whiteSpace="pre">
-        { `<Form
+    >
+      <Stack spacing={ 4 } w="60%">
+        <H2>
+          Our forms are built on{ ' ' }
+          <Link
+            color="blue.600"
+            _hover={ { textDecoration: 'underline' } }
+            href="https://react-hook-form.com/api"
+            isExternal={ true }
+          >
+            React Hook Form
+          </Link>
+        </H2>
+        <P>
+          Mediatool uses one <strong>{ '<Form />' }</strong> Component{ ' ' }
+        </P>
+        <Code w="max-content" display="block" whiteSpace="pre">
+          { `<Form
     initialValues={ {} }
     onSubmit={ () => {} }
   >
@@ -66,67 +76,109 @@ const FormPage = () => (
     }}
 </Form>
 ` }
-      </Code>
-      <Divider />
-      <P>It takes the following props</P>
-      <P>
-        <strong>initialValues </strong>- this should contain an object with the
-        name of the fields and their default values.
-      </P>
-      <P>
-        <strong>onSubmit </strong>- This is a function on the form ( formValues
-        , methods ) { '=>' } any | { 'Promise<any>' }
-      </P>
-      <P>
-        <strong>validate </strong>- This should be a function that
-        returns an object with the form errors, look at the file validation
-        in form-demo-page/validation to see how to write validation
-      </P>
-      <P>
-        <strong>formSettings </strong>
-        - This can be used to customize the form, look at <br />
-        <Link
-          href="https://react-hook-form.com/api/useform"
-          color="blue.600"
-          _hover={ { textDecoration: 'underline' } }
-          isExternal={ true }
+        </Code>
+        <Divider />
+        <P>It takes the following props</P>
+        <P>
+          <strong>initialValues </strong>- this should contain an object with the
+          name of the fields and their default values.
+        </P>
+        <P>
+          <strong>onSubmit </strong>- This is a function on the form ( formValues
+          , methods ) { '=>' } any | { 'Promise<any>' }
+        </P>
+        <P>
+          <strong>validate </strong>- This should be a function that returns an
+          object with the form errors, look at the file validation in
+          form-demo-page/validation to see how to write validation
+        </P>
+        <P>
+          <strong>ref</strong>- By setting a ref to { '<Form />' } it initializes
+          the ref to contain the form context, this is useful for lifting the
+          state.
+        </P>
+        <P>
+          <strong>formSettings </strong>
+          - This can be used to customize the form, look at <br />
+          <Link
+            href="https://react-hook-form.com/api/useform"
+            color="blue.600"
+            _hover={ { textDecoration: 'underline' } }
+            isExternal={ true }
+          >
+            React Hook Form useForm Docs
+          </Link>
+          , all the options you can pass down to useForm, you can pass down to
+          formSettings,
+        </P>
+        <P>
+          <strong>children </strong>
+          - Any valid JSX, can also be types as a function on the form <br />
+          (methods) { '=>' } (JSX), where methods contain the form context, and is
+          equivalent to the return value of useForm
+        </P>
+        <P>
+          <strong>enableReinitialize </strong>
+          Just as in formik, this uses a useEffect hook to reinitalize the form
+          every time the initialValues change using a deep compare
+        </P>
+        <P>
+          <strong>methods </strong>
+          - In the edge case that you need to initialize the form with the useForm
+          hook outside of the Form component, <br />
+          you can initalize the form as usual and pass down your custom methods as
+          a prop.
+        </P>
+        <P>
+          <b>shouldTrim </b>- boolean, if true then all form values, no matter how
+          nested will be trimmed if they are a string. Default is true
+        </P>
+        <Divider />
+        <H3>About the scope of the state</H3>
+        <P>
+          Say that you need to access the form context api outside
+          the { '<Form />' },
+          to do this you can use
+          the exposed formMethods <b>ref</b>
+        </P>
+        <P>Example: </P>
+        <Code w="max-content" display="block" whiteSpace="pre">
+          { `import { UseFormReturn } from '@northlight/ui'
+
+const initialValues = { firstName: '' } 
+const formMethods = useRef<UseFormReturn<typeof initialValues>>(null)
+
+const getNewName = () => {
+  if (!formMethods.current) return
+  formMethods.current.reset({ firstName: Math.random().toString(36) })
+}
+
+<Form
+  initialValues={ initialValues }
+  onSubmit={ handleSubmit }
+  ref={ formMethods }
+  enableReinitialize={ true }
+  >
+    <TextField name="firstName" label="First Name" />
+    <Button type="button" onClick={ getNewName }>Compute new name</Button>
+</Form>` }
+        </Code>
+
+        <Form
+          onSubmit={ () => {} }
+          initialValues={ initialValues }
+          ref={ formMethods }
+          enableReinitialize={ true }
         >
-          React Hook Form useForm Docs
-        </Link>
-        , all the options you can pass down to useForm, you can pass down to
-        formSettings,
-      </P>
-      <P>
-        <strong>children </strong>
-        - Any valid JSX, can also be types as a function on the form <br />
-        (methods) { '=>' } (JSX), where methods contain the form context,
-        and is equivalent to the return value of useForm
-      </P>
-      <P>
-        <strong>enableReinitialize </strong>
-        Just as in formik, this uses a useEffect hook to
-        reinitalize the form every time the initialValues change using a deep compare
-      </P>
-      <P>
-        <strong>methods </strong>
-        - In the edge case that you need to initialize the form with the useForm
-        hook outside of the Form component, <br />
-        you can initalize the form as usual and pass down your custom methods as
-        a prop.
-      </P>
-      <P>
-        <b>shouldTrim </b>
-        - boolean, if true then all form values,
-        no matter how nested will be trimmed if they are a string.
-        Default is true
-      </P>
-      <Divider />
-      <HStack spacing={ 8 } alignItems="start">
-        <Stack>
-          <Blockquote>Example 1</Blockquote>
-          <P>This is recommended</P>
-          <Code w="max-content" display="block" whiteSpace="pre">
-            { `const validation = (values: any) => {
+          <TextField name="firstName" label="First Name" />
+          <Button type="button" onClick={ getNewName }>Compute new name</Button>
+        </Form>
+        <HStack spacing={ 8 } alignItems="start">
+          <Stack>
+            <Blockquote>Example 1</Blockquote>
+            <P>This is recommended</P>
+            <Code w="max-content" display="block" whiteSpace="pre">
+              { `const validation = (values: any) => {
   const errors: any = {}
   if (values.firstName === 'admin') {
     errors.firstName = {
@@ -161,13 +213,13 @@ const FormPage = () => (
   </HStack>
 </Form>
 ` }
-          </Code>
-        </Stack>
-        <Stack>
-          <Blockquote>Example 2</Blockquote>
-          <P>This accomplishes the same thing but with methods prop</P>
-          <Code w="max-content" display="block" whiteSpace="pre">
-            { `import { useForm } from '@northlight/ui'
+            </Code>
+          </Stack>
+          <Stack>
+            <Blockquote>Example 2</Blockquote>
+            <P>This accomplishes the same thing but with methods prop</P>
+            <Code w="max-content" display="block" whiteSpace="pre">
+              { `import { useForm } from '@northlight/ui'
 const validation = (values: any) => {
   const errors: any = {}
   if (values.firstName === 'admin') {
@@ -208,39 +260,41 @@ const methods = useForm({
   </HStack>
 </Form>
 ` }
-          </Code>
-        </Stack>
-      </HStack>
-      <Divider />
-      <Form
-        initialValues={ { firstName: '' } }
-        onSubmit={ () => {} }
-        formSettings={ {
-          mode: 'onSubmit',
-        } }
-        validate={ validation }
-      >
-        <Stack w="300px">
-          <TextField name="firstName" label="First Name" isRequired={ true } />
-          <Button type="submit" variant="success">
-            Validate
-          </Button>
-        </Stack>
-      </Form>
-      <VStack w="50%" spacing={ 4 }>
-        <P>
-          Both example 1 and example 2 yield the same above field,
-          but the difference being in the scope of the state,
-          in example 2 the form state can be accessed throughtout the entire component,
-          and not just as a child within the { '<Form> tag' }.
-        </P>
-        <P>
-          Example 1 is still recommended however because it abstracts more away
-          which makes it easier for future changes, example 2 should be used just when needed.
-        </P>
-      </VStack>
-    </Stack>
-  </Page>
-)
+            </Code>
+          </Stack>
+        </HStack>
+        <Divider />
+        <Form
+          initialValues={ { firstName: '' } }
+          onSubmit={ () => {} }
+          formSettings={ {
+            mode: 'onSubmit',
+          } }
+          validate={ validation }
+        >
+          <Stack w="300px">
+            <TextField name="firstName" label="First Name" isRequired={ true } />
+            <Button type="submit" variant="success">
+              Validate
+            </Button>
+          </Stack>
+        </Form>
+        <VStack w="50%" spacing={ 4 }>
+          <P>
+            Both example 1 and example 2 yield the same above field, but the
+            difference being in the scope of the state, in example 2 the form
+            state can be accessed throughtout the entire component, and not just
+            as a child within the { '<Form> tag' }.
+          </P>
+          <P>
+            Example 1 is still recommended however because it abstracts more away
+            which makes it easier for future changes, example 2 should be used
+            just when needed.
+          </P>
+        </VStack>
+      </Stack>
+    </Page>
+  )
+}
 
 export default FormPage


### PR DESCRIPTION
Previousely the form context was closed within
the <Form> tag itself, thus the form context api
was not available to methods outside of it, and
the form had to be refactored with the useForm hook to work properly.

Now a ref has been added that should act as syntax sugar to simplify this process