### PR TITLE
fix(framework): update toolbox z-index with token value

### DIFF
--- a/framework/lib/components/toolbox/toolbox.tsx
+++ b/framework/lib/components/toolbox/toolbox.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { useMultiStyleConfig } from '@chakra-ui/system'
+import { coreZIndex } from '@northlight/tokens'
 import { FocusScope } from '@react-aria/focus'
 import { Flex } from '../flex'
 import { Slide } from '../transitions'
@@ -38,7 +39,7 @@ export const Toolbox = ({
           style={ {
             height: container.h as string,
             width: container.w as string,
-            zIndex: '1000',
+            zIndex: coreZIndex.overlay,
           } }
         >
           <Flex sx={ container } { ...rest } onKeyDown={ handleKeyDown }>


### PR DESCRIPTION
When a value from the theme cannot be resolved we should
import the appriopiate value from @northlight/tokens
and resolve it ourselves.