### PR TITLE
fix(framework): change default textDecoration

### DIFF
--- a/framework/lib/components/clickable/clickable.tsx
+++ b/framework/lib/components/clickable/clickable.tsx
@@ -16,6 +16,7 @@ export const Clickable = ({ href, linkProps, ...rest }: ClickableProps) => {
           as={ ReactRouterLink }
           _focusVisible={ ring }
           to={ href }
+          _hover={ { textDecoration: 'none' } }
           { ...linkProps }
           { ...clickable }
         />


### PR DESCRIPTION
Idk why, the linkProps prop works fine in the sandbox enviroment in northlight.
But when trying in the domain sandbox the text decoration is still underline

Defaulting it to have no textDecoration should fix it, and we should probably
have it like that anyway, as when you use the clickable as a wrapper you 
don't want the text to be underlined