### PR TITLE
chore(framework): change names from mediatool to northlight

### DIFF
--- a/framework/README.md
+++ b/framework/README.md
@@ -1,35 +1,43 @@
-# Mediatool UI framework
+# Northlight UI framework
+
 This awesome collection of components, built upon Chakra, powers all of Mediatool's features.
 
 ## Get started
+
 1. Run `yarn`
 2. Run `yarn start`
 3. Navigate to http://localhost:3008
 
 ## Overview
+
 Below you'll find an overview of each part of the library.
 
-  ### lib
-  In this folder you'll find components, hooks, utils and theme. This is the actual library and is what gets published to npm.
+### lib
 
-  ### sandbox
-  Sandbox is what you'd expect from the name - a sandbox environment. It serves as documentation as well as a playground for testing new components in an interactive enrivonment.
-  Sandbox is built like a mini micro frontend, meaning that `docs` and `demo` are 2 separate mini apps. `Docs` is the default fallback when navigating to localhost:3008/.
+In this folder you'll find components, hooks, utils and theme. This is the actual library and is what gets published to npm.
 
-  `Docs` works similarly to how Storybook works, without the need to write explicit stories. Simply follow existing structure and create a component under `docs/pages`, and write code just how you normally would.
-  `Test` was created by Sebastian. However he was not aware that other main pages were documented here, thus he didn't write any explanation.
+### sandbox
+
+Sandbox is what you'd expect from the name - a sandbox environment. It serves as documentation as well as a playground for testing new components in an interactive enrivonment.
+Sandbox is built like a mini micro frontend, meaning that `docs` and `demo` are 2 separate mini apps. `Docs` is the default fallback when navigating to localhost:3008/.
+
+`Docs` works similarly to how Storybook works, without the need to write explicit stories. Simply follow existing structure and create a component under `docs/pages`, and write code just how you normally would.
+`Test` was created by Sebastian. However he was not aware that other main pages were documented here, thus he didn't write any explanation.
 
 ## Contribute
+
 Want to contribute? Awesome! Find what suits your use-case below and follow the steps.
 
-  ### I need to create a new component
-  1. Create a new folder under `lib/components`
-  2. Create a file inside of the folder and write your component
-  3. Export the component from an index file `lib/components/my-new-component/index.ts`
-  4. Export your folder in `lib/components/index.ts`
+### I need to create a new component
 
-  ### I need to create a new hook
-  1. Create a new folder under `lib/hooks`
-  2. Create a file inside of the folder and write your hook
-  3. Export the hook from an index file `lib/hooks/my-new-hook/index.ts`
-  4. Export your folder in `lib/hooks/index.ts`
+1. Create a new folder under `lib/components`
+2. Create a file inside of the folder and write your component
+3. Export the component from an index file `lib/components/my-new-component/index.ts`
+4. Export your folder in `lib/components/index.ts`
+
+### I need to create a new hook
+
+1. Create a new folder under `lib/hooks`
+2. Create a file inside of the folder and write your hook
+3. Export the hook from an index file `lib/hooks/my-new-hook/index.ts`
+4. Export your folder in `lib/hooks/index.ts`

--- a/framework/package.json
+++ b/framework/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@northlight/ui",
   "version": "1.4.2",
-  "description": "Mediatool UI library, based on Chakra-ui",
+  "description": "Northlight UI library, based on Chakra-ui",
   "license": "MIT",
   "author": "Mediatool",
   "exports": {

--- a/framework/sandbox/docs/app.tsx
+++ b/framework/sandbox/docs/app.tsx
@@ -488,12 +488,12 @@ const DocsApp = () => {
                 Developed from the Giants at <Icon color="blue.500" as={ MediatoolLogoSolid } boxSize={ 5 } ml={ 2 } alignSelf="flex-end" flexGrow={ 1 } />
               </Lead>
               <Tiny maxW="100vh" textAlign="center">
-                Mediatool UI is not responsible for any possible deaths of
-                users. Mediatool UI is not responsible for badly written code.
-                Mediatool UI do proudly collect its users data. By installing
-                Mediatool UI the developer agrees to all of this requirments as
+                Northlight UI is not responsible for any possible deaths of
+                users. Northlight UI is not responsible for badly written code.
+                Northlight UI do proudly collect its users data. By installing
+                Northlight UI the developer agrees to all of this requirments as
                 stated above and agrees to give away half their salary to
-                Mediatool UI creators as "donations"
+                Northlight UI creators as "donations"
               </Tiny>
             </VStack>
           </VStack>

--- a/framework/sandbox/docs/pages/file-picker-page/index.tsx
+++ b/framework/sandbox/docs/pages/file-picker-page/index.tsx
@@ -282,7 +282,7 @@ const FilePickerPage = () => {
 />` }
           </Code>
           <P>
-            To enable more developer control, mediatool ui also exports a multi
+            To enable more developer control, Northlight ui also exports a multi
             file uploader, which provides the same methods such as onChange, but
             does not render any UI file-items
           </P>


### PR DESCRIPTION
small change of the name mediatool to northlight. Seems like we forgot to update it in some places.