### PR TITLE
feat(tokens): 84 New tokens

### DIFF
--- a/framework/lib/theme/index.ts
+++ b/framework/lib/theme/index.ts
@@ -54,7 +54,9 @@ const overrides: ThemeOverride = {
   fontSizes: coreFontSize,
   lineHeights: coreLineHeight,
   radii: coreBorderRadius,
+  borderWidths: WebappSkin.borders,
 }
 
 export const theme = extendTheme(overrides, WebappSkin)
+
 export const tottTheme = extendTheme(overrides, TottSkin)

--- a/framework/lib/theme/skins/tott/index.ts
+++ b/framework/lib/theme/skins/tott/index.ts
@@ -11,5 +11,6 @@ export const TottSkin:ThemeOverride = {
   radii: TottSkinTokens.borderRadius,
   borders: TottSkinTokens.borderWidth,
   opacity: TottSkinTokens.opacity,
+  shadows: TottSkinTokens.boxShadow,
   typography,
 }

--- a/framework/lib/theme/skins/webapp/index.ts
+++ b/framework/lib/theme/skins/webapp/index.ts
@@ -12,4 +12,5 @@ export const WebappSkin:ThemeOverride = {
   borders: WebappSkinTokens.borderWidth,
   opacity: WebappSkinTokens.opacity,
   typography,
+  shadows: WebappSkinTokens.boxShadow,
 }

--- a/tokens/lib/tokens.json
+++ b/tokens/lib/tokens.json
@@ -1694,6 +1694,497 @@
     "ghost": {
       "value": "{color.mono.transparent}",
       "type": "color"
+    },
+    "st": {
+      "color": {
+        "bg": {
+          "base": {
+            "value": "{color.gray.900}",
+            "type": "color"
+          },
+          "layer": {
+            "value": "{color.gray.800}",
+            "type": "color"
+          },
+          "overlayer": {
+            "value": "{color.gray.700}",
+            "type": "color"
+          },
+          "brand": {
+            "default": {
+              "value": "{brand}",
+              "type": "color"
+            },
+            "active": {
+              "value": "{brand}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{brand}{alpha.hover-full}",
+              "type": "color"
+            }
+          },
+          "secondary": {
+            "default": {
+              "value": "{color.green.400}",
+              "type": "color"
+            },
+            "active": {
+              "value": "{color.green.400}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{color.green.400}{alpha.hover-full}",
+              "type": "color"
+            }
+          },
+          "tertiary": {
+            "default": {
+              "value": "{color.mediatoolBlue.400}",
+              "type": "color"
+            },
+            "active": {
+              "value": "{color.mediatoolBlue.400}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{color.mediatoolBlue.400}{alpha.hover-full}",
+              "type": "color"
+            }
+          },
+          "success": {
+            "default": {
+              "value": "{success-alt}",
+              "type": "color"
+            },
+            "active": {
+              "value": "{success-alt}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{success-alt}{alpha.hover-full}",
+              "type": "color"
+            }
+          },
+          "error": {
+            "default": {
+              "value": "{destructive-alt}",
+              "type": "color"
+            },
+            "active": {
+              "value": "{destructive-alt}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{destructive-alt}{alpha.hover-full}",
+              "type": "color"
+            }
+          },
+          "warning": {
+            "default": {
+              "value": "{warning-alt}",
+              "type": "color"
+            },
+            "active": {
+              "value": "{warning-alt}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{warning-alt}{alpha.hover-full}",
+              "type": "color"
+            }
+          },
+          "info": {
+            "default": {
+              "value": "{info-alt}",
+              "type": "color"
+            },
+            "active": {
+              "value": "{info-alt}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{info-alt}{alpha.hover-full}",
+              "type": "color"
+            }
+          },
+          "filled": {
+            "value": "{base-alt}",
+            "type": "color"
+          },
+          "ghost": {
+            "default": {
+              "value": "{ghost}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{ghost}{alpha.hover-full}",
+              "type": "color"
+            },
+            "active": {
+              "value": "{ghost}",
+              "type": "color"
+            }
+          }
+        },
+        "border": {
+          "default": {
+            "value": "{color.mono.white}",
+            "type": "color"
+          },
+          "hover": {
+            "value": "{color.gray.50}",
+            "type": "color"
+          },
+          "error": {
+            "value": "{destructive}",
+            "type": "color"
+          },
+          "warning": {
+            "value": "{warning}",
+            "type": "color"
+          },
+          "info": {
+            "value": "{info}",
+            "type": "color"
+          },
+          "success": {
+            "value": "{success}",
+            "type": "color"
+          },
+          "brand": {
+            "default": {
+              "value": "{color.blue.600}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{color.blue.600}{alpha.hover-full}",
+              "type": "color"
+            },
+            "active": {
+              "value": "{color.blue.600}",
+              "type": "color"
+            }
+          },
+          "secondary": {
+            "default": {
+              "value": "{color.green.600}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{color.green.600}{alpha.hover-full}",
+              "type": "color"
+            },
+            "active": {
+              "value": "{color.green.600}",
+              "type": "color",
+              "description": " "
+            }
+          },
+          "tertiary": {
+            "default": {
+              "value": "{color.mediatoolBlue.600}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{color.mediatoolBlue.600}{alpha.hover-full}",
+              "type": "color"
+            },
+            "active": {
+              "value": "{color.mediatoolBlue.600}",
+              "type": "color"
+            }
+          }
+        },
+        "font": {
+          "success": {
+            "value": "{color.green.50}",
+            "type": "color"
+          },
+          "error": {
+            "value": "{color.red.50}",
+            "type": "color"
+          },
+          "warning": {
+            "value": "{color.orange.50}",
+            "type": "color"
+          },
+          "info": {
+            "value": "{color.yellow.50}",
+            "type": "color"
+          },
+          "brand": {
+            "value": "{color.blue.50}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{color.green.50}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{color.mediatoolBlue.50}",
+            "type": "color"
+          }
+        },
+        "brand": {
+          "50": {
+            "value": "{color.blue.50}",
+            "type": "color"
+          },
+          "100": {
+            "value": "{color.blue.100}",
+            "type": "color"
+          },
+          "200": {
+            "value": "{color.blue.200}",
+            "type": "color"
+          },
+          "300": {
+            "value": "{color.blue.300}",
+            "type": "color"
+          },
+          "400": {
+            "value": "{color.blue.400}",
+            "type": "color"
+          },
+          "500": {
+            "value": "{color.blue.500}",
+            "type": "color"
+          },
+          "600": {
+            "value": "{color.blue.600}",
+            "type": "color"
+          },
+          "700": {
+            "value": "{color.blue.700}",
+            "type": "color"
+          },
+          "800": {
+            "value": "{color.blue.800}",
+            "type": "color"
+          },
+          "900": {
+            "value": "{color.blue.900}",
+            "type": "color"
+          }
+        }
+      },
+      "border": {
+        "width": {
+          "xs": {
+            "value": "{borderWidth.xs}'",
+            "type": "borderWidth"
+          },
+          "sm": {
+            "value": "{borderWidth.sm}",
+            "type": "borderWidth"
+          },
+          "md": {
+            "value": "{borderWidth.md}",
+            "type": "borderWidth"
+          },
+          "lg": {
+            "value": "{borderWidth.lg}",
+            "type": "borderWidth"
+          },
+          "xl": {
+            "value": "{borderWidth.xl}",
+            "type": "borderWidth"
+          }
+        },
+        "radius": {
+          "xs": {
+            "value": "{borderRadius.xs}",
+            "type": "borderRadius"
+          },
+          "sm": {
+            "value": "{borderRadius.sm}",
+            "type": "borderRadius"
+          },
+          "md": {
+            "value": "{borderRadius.md}",
+            "type": "borderRadius"
+          },
+          "lg": {
+            "value": "{borderRadius.lg}",
+            "type": "borderRadius"
+          },
+          "xl": {
+            "value": "{borderRadius.xl}",
+            "type": "borderRadius"
+          }
+        }
+      },
+      "boxshadow": {
+        "brand": {
+          "default": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{brand}{alpha.hover-soft}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          },
+          "hover": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{brand}{alpha.hover-full}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          }
+        },
+        "secondary": {
+          "default": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{color.bg.secondary.default}{alpha.hover-soft}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          },
+          "hover": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{st.color.bg.secondary.default}{alpha.hover-full}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          }
+        },
+        "tertiary": {
+          "default": {
+            "value": {
+              "x": "0",
+              "y": "10",
+              "blur": "0",
+              "spread": "0",
+              "color": "{color.bg.tertiary.default}{alpha.hover-soft}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          },
+          "hover": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{color.bg.tertiary.default}{alpha.hover-full}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          }
+        },
+        "info": {
+          "default": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{info}{alpha.hover-soft}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          },
+          "hover": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{info}{alpha.hover-full}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          }
+        },
+        "warning": {
+          "default": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{warning}{alpha.hover-soft}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          },
+          "hover": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{warning}{alpha.hover-full}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          }
+        },
+        "success": {
+          "default": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{success}{alpha.hover-soft}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          },
+          "hover": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{success}{alpha.hover-full}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          }
+        },
+        "error": {
+          "default": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{destructive}{alpha.hover-soft}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          },
+          "hover": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{destructive}{alpha.hover-full}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          }
+        }
+      }
     }
   },
   "webapp": {
@@ -1786,6 +2277,496 @@
     "ghost": {
       "value": "{color.mono.transparent}",
       "type": "color"
+    },
+    "st": {
+      "color": {
+        "bg": {
+          "base": {
+            "value": "{color.mono.white}",
+            "type": "color"
+          },
+          "layer": {
+            "value": "{color.gray.50}",
+            "type": "color"
+          },
+          "overlayer": {
+            "value": "{color.gray.100}",
+            "type": "color"
+          },
+          "brand": {
+            "default": {
+              "value": "{brand}",
+              "type": "color"
+            },
+            "active": {
+              "value": "{brand}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{brand}{alpha.hover-full}",
+              "type": "color"
+            }
+          },
+          "secondary": {
+            "default": {
+              "value": "{color.green.500}",
+              "type": "color"
+            },
+            "active": {
+              "value": "{color.green.500}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{color.green.500}{alpha.hover-full}",
+              "type": "color"
+            }
+          },
+          "tertiary": {
+            "default": {
+              "value": "{color.mediatoolBlue.500}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{color.mediatoolBlue.500}{alpha.hover-full}",
+              "type": "color"
+            },
+            "active": {
+              "value": "{color.mediatoolBlue.500}",
+              "type": "color"
+            }
+          },
+          "success": {
+            "default": {
+              "value": "{success-alt}",
+              "type": "color"
+            },
+            "active": {
+              "value": "{success-alt}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{success-alt}{alpha.hover-full}",
+              "type": "color"
+            }
+          },
+          "error": {
+            "default": {
+              "value": "{destructive-alt}",
+              "type": "color"
+            },
+            "active": {
+              "value": "{destructive-alt}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{destructive-alt}{alpha.hover-full}",
+              "type": "color"
+            }
+          },
+          "warning": {
+            "default": {
+              "value": "{warning-alt}",
+              "type": "color"
+            },
+            "active": {
+              "value": "{warning-alt}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{warning-alt}{alpha.hover-full}",
+              "type": "color"
+            }
+          },
+          "info": {
+            "default": {
+              "value": "{info-alt}",
+              "type": "color"
+            },
+            "active": {
+              "value": "{info-alt}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{info-alt}{alpha.hover-full}",
+              "type": "color"
+            }
+          },
+          "ghost": {
+            "default": {
+              "value": "{ghost}",
+              "type": "color"
+            },
+            "active": {
+              "value": "{ghost}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{ghost}{alpha.hover-full}",
+              "type": "color"
+            }
+          },
+          "filled": {
+            "value": "{base-alt}",
+            "type": "color"
+          }
+        },
+        "border": {
+          "default": {
+            "value": "{color.gray.200}",
+            "type": "color"
+          },
+          "hover": {
+            "value": "{color.gray.200}{alpha.hover-soft}",
+            "type": "color"
+          },
+          "error": {
+            "value": "{destructive}",
+            "type": "color"
+          },
+          "warning": {
+            "value": "{warning}",
+            "type": "color"
+          },
+          "info": {
+            "value": "{info}",
+            "type": "color"
+          },
+          "success": {
+            "value": "{success}",
+            "type": "color"
+          },
+          "brand": {
+            "default": {
+              "value": "{color.blue.400}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{color.blue.400}{alpha.hover-soft}",
+              "type": "color"
+            },
+            "active": {
+              "value": "{color.blue.400}",
+              "type": "color"
+            }
+          },
+          "secondary": {
+            "default": {
+              "value": "{color.green.400}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{color.green.400}{alpha.hover-soft}",
+              "type": "color"
+            },
+            "active": {
+              "value": "{color.green.400}",
+              "type": "color"
+            }
+          },
+          "tertiary": {
+            "default": {
+              "value": "{color.mediatoolBlue.400}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{color.mediatoolBlue.400}{alpha.hover-soft}",
+              "type": "color"
+            },
+            "active": {
+              "value": "{color.mediatoolBlue.400}",
+              "type": "color"
+            }
+          }
+        },
+        "font": {
+          "success": {
+            "value": "{color.green.800}",
+            "type": "color"
+          },
+          "error": {
+            "value": "{color.red.800}",
+            "type": "color"
+          },
+          "warning": {
+            "value": "{color.orange.800}",
+            "type": "color"
+          },
+          "info": {
+            "value": "{color.yellow.800}",
+            "type": "color"
+          },
+          "brand": {
+            "value": "{color.blue.800}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{color.green.800}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{color.mediatoolBlue.800}",
+            "type": "color"
+          }
+        },
+        "brand": {
+          "50": {
+            "value": "{color.blue.50}",
+            "type": "color"
+          },
+          "100": {
+            "value": "{color.blue.100}",
+            "type": "color"
+          },
+          "200": {
+            "value": "{color.blue.200}",
+            "type": "color"
+          },
+          "300": {
+            "value": "{color.blue.300}",
+            "type": "color"
+          },
+          "400": {
+            "value": "{color.blue.400}",
+            "type": "color"
+          },
+          "500": {
+            "value": "{color.blue.500}",
+            "type": "color"
+          },
+          "600": {
+            "value": "{color.blue.600}",
+            "type": "color"
+          },
+          "700": {
+            "value": "{color.blue.700}",
+            "type": "color"
+          },
+          "800": {
+            "value": "{color.blue.800}",
+            "type": "color"
+          },
+          "900": {
+            "value": "{color.blue.900}",
+            "type": "color"
+          }
+        }
+      },
+      "border": {
+        "width": {
+          "xs": {
+            "value": "{borderWidth.xs}",
+            "type": "borderWidth"
+          },
+          "sm": {
+            "value": "{borderWidth.sm}",
+            "type": "borderWidth"
+          },
+          "md": {
+            "value": "{borderWidth.md}",
+            "type": "borderWidth"
+          },
+          "lg": {
+            "value": "{borderWidth.lg}",
+            "type": "borderWidth"
+          },
+          "xl": {
+            "value": "{borderWidth.xl}",
+            "type": "borderWidth"
+          }
+        },
+        "radius": {
+          "xs": {
+            "value": "{borderRadius.xs}",
+            "type": "borderRadius"
+          },
+          "sm": {
+            "value": "{borderRadius.sm}",
+            "type": "borderRadius"
+          },
+          "md": {
+            "value": "{borderRadius.md}",
+            "type": "borderRadius"
+          },
+          "lg": {
+            "value": "{borderRadius.lg}",
+            "type": "borderRadius"
+          },
+          "xl": {
+            "value": "{borderRadius.xl}",
+            "type": "borderRadius"
+          }
+        }
+      },
+      "boxshadow": {
+        "brand": {
+          "default": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{brand}{alpha.hover-soft}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          },
+          "hover": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{brand}{alpha.hover-full}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          }
+        },
+        "secondary": {
+          "default": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{st.color.bg.secondary.default}{alpha.hover-soft}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          },
+          "hover": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{st.color.bg.secondary.default}{alpha.hover-full}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          }
+        },
+        "tertiary": {
+          "default": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{st.color.bg.tertiary.default}{alpha.hover-soft}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          },
+          "hover": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{st.color.bg.tertiary.default}{alpha.hover-full}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          }
+        },
+        "info": {
+          "default": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{info}{alpha.hover-soft}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          },
+          "hover": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{info}{alpha.hover-full}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          }
+        },
+        "warning": {
+          "default": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{warning}{alpha.hover-soft}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          },
+          "hover": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{warning}{alpha.hover-full}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          }
+        },
+        "error": {
+          "default": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{destructive}{alpha.hover-soft}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          },
+          "hover": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{destructive}{alpha.hover-full}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          }
+        },
+        "success": {
+          "default": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{success}{alpha.hover-soft}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          },
+          "hover": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "10",
+              "spread": "0",
+              "color": "{success}{alpha.hover-full}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -2398,6 +3379,34 @@
             "value": "{inverted}",
             "type": "color"
           }
+        },
+        "error": {
+          "value": "{st.color.font.error}",
+          "type": "color"
+        },
+        "success": {
+          "value": "{st.color.font.success}",
+          "type": "color"
+        },
+        "info": {
+          "value": "{st.color.font.info}",
+          "type": "color"
+        },
+        "warning": {
+          "value": "{st.color.font.warning}",
+          "type": "color"
+        },
+        "brand": {
+          "value": "{st.color.font.brand}",
+          "type": "color"
+        },
+        "secondary": {
+          "value": "{st.color.font.secondary}",
+          "type": "color"
+        },
+        "tertiary": {
+          "value": "{st.color.font.tertiary}",
+          "type": "color"
         }
       },
       "border": {
@@ -2564,6 +3573,72 @@
             "value": "{brand}",
             "type": "color"
           }
+        },
+        "default": {
+          "value": "{st.color.border.default}",
+          "type": "color"
+        },
+        "hover": {
+          "value": "{st.color.border.hover}",
+          "type": "color"
+        },
+        "error": {
+          "value": "{st.color.border.error}",
+          "type": "color"
+        },
+        "warning": {
+          "value": "{st.color.border.warning}",
+          "type": "color"
+        },
+        "info": {
+          "value": "{st.color.border.info}",
+          "type": "color"
+        },
+        "success": {
+          "value": "{st.color.border.success}",
+          "type": "color"
+        },
+        "brand": {
+          "default": {
+            "value": "{st.color.border.brand.default}",
+            "type": "color"
+          },
+          "active": {
+            "value": "{st.color.border.brand.active}",
+            "type": "color"
+          },
+          "hover": {
+            "value": "{st.color.border.brand.hover}",
+            "type": "color"
+          }
+        },
+        "secondary": {
+          "default": {
+            "value": "{st.color.border.secondary.default}",
+            "type": "color"
+          },
+          "hover": {
+            "value": "{st.color.border.secondary.hover}",
+            "type": "color"
+          },
+          "active": {
+            "value": "{st.color.border.secondary.active}",
+            "type": "color"
+          }
+        },
+        "tertiary": {
+          "default": {
+            "value": "{st.color.border.tertiary.default}",
+            "type": "color"
+          },
+          "hover": {
+            "value": "{st.color.border.tertiary.hover}",
+            "type": "color"
+          },
+          "active": {
+            "value": "{st.color.border.tertiary.active}",
+            "type": "color"
+          }
         }
       },
       "icon": {
@@ -2617,6 +3692,182 @@
           "default": {
             "value": "{brand}",
             "type": "color"
+          }
+        }
+      },
+      "bg": {
+        "base": {
+          "value": "{st.color.bg.base}",
+          "type": "color"
+        },
+        "layer": {
+          "value": "{st.color.bg.layer}",
+          "type": "color"
+        },
+        "overlayer": {
+          "value": "{st.color.bg.overlayer}",
+          "type": "color"
+        },
+        "brand": {
+          "default": {
+            "value": "{st.color.bg.brand.default}",
+            "type": "color"
+          },
+          "hover": {
+            "value": "{st.color.bg.brand.hover}",
+            "type": "color"
+          },
+          "active": {
+            "value": "{st.color.bg.brand.active}",
+            "type": "color"
+          }
+        },
+        "secondary": {
+          "default": {
+            "value": "{st.color.bg.secondary.default}",
+            "type": "color"
+          },
+          "active": {
+            "value": "{st.color.bg.secondary.active}",
+            "type": "color"
+          },
+          "hover": {
+            "value": "{st.color.bg.secondary.hover}",
+            "type": "color"
+          }
+        },
+        "tertiary": {
+          "default": {
+            "value": "{st.color.bg.tertiary.default}",
+            "type": "color"
+          },
+          "hover": {
+            "value": "{st.color.bg.tertiary.hover}",
+            "type": "color"
+          },
+          "active": {
+            "value": "{st.color.bg.tertiary.active}",
+            "type": "color"
+          }
+        },
+        "success": {
+          "default": {
+            "value": "{st.color.bg.success.default}",
+            "type": "color"
+          },
+          "hover": {
+            "value": "{st.color.bg.success.hover}",
+            "type": "color"
+          },
+          "active": {
+            "value": "{st.color.bg.success.active}",
+            "type": "color"
+          }
+        },
+        "error": {
+          "default": {
+            "value": "{st.color.bg.error.default}",
+            "type": "color"
+          },
+          "hover": {
+            "value": "{st.color.bg.error.hover}",
+            "type": "color"
+          },
+          "active": {
+            "value": "{st.color.bg.error.active}",
+            "type": "color"
+          }
+        },
+        "warning": {
+          "default": {
+            "value": "{st.color.bg.warning.default}",
+            "type": "color"
+          },
+          "hover": {
+            "value": "{st.color.bg.warning.hover}",
+            "type": "color"
+          },
+          "active": {
+            "value": "{st.color.bg.warning.active}",
+            "type": "color"
+          }
+        },
+        "info": {
+          "default": {
+            "value": "{st.color.bg.info.default}",
+            "type": "color"
+          },
+          "hover": {
+            "value": "{st.color.bg.info.hover}",
+            "type": "color"
+          },
+          "active": {
+            "value": "{st.color.bg.info.active}",
+            "type": "color"
+          }
+        },
+        "ghost": {
+          "default": {
+            "value": "{st.color.bg.ghost.default}",
+            "type": "color"
+          },
+          "hover": {
+            "value": "{st.color.bg.ghost.hover}",
+            "type": "color"
+          },
+          "active": {
+            "value": "{st.color.bg.ghost.active}",
+            "type": "color"
+          }
+        },
+        "filled": {
+          "value": "{st.color.bg.filled}",
+          "type": "color"
+        }
+      },
+      "st": {
+        "color": {
+          "brand": {
+            "50": {
+              "value": "{st.color.brand.50}",
+              "type": "color"
+            },
+            "100": {
+              "value": "{st.color.brand.100}",
+              "type": "color"
+            },
+            "200": {
+              "value": "{st.color.brand.200}",
+              "type": "color"
+            },
+            "300": {
+              "value": "{st.color.brand.300}",
+              "type": "color"
+            },
+            "400": {
+              "value": "{st.color.brand.400}",
+              "type": "color"
+            },
+            "500": {
+              "value": "{st.color.brand.500}",
+              "type": "color"
+            },
+            "600": {
+              "value": "{st.color.brand.600}",
+              "type": "color"
+            },
+            "700": {
+              "value": "{st.color.brand.700}",
+              "type": "color"
+            },
+            "800": {
+              "value": "{st.color.brand.800}",
+              "type": "color"
+            },
+            "900": {
+              "value": "{st.color.brand.900}",
+              "type": "color"
+            }
           }
         }
       }
@@ -2793,6 +4044,32 @@
           "value": "{borderRadius.full}",
           "type": "borderRadius"
         }
+      },
+      "st": {
+        "border": {
+          "radius": {
+            "sm": {
+              "value": "{st.border.radius.sm}",
+              "type": "borderRadius"
+            },
+            "xs": {
+              "value": "{st.border.radius.xs}",
+              "type": "borderRadius"
+            },
+            "md": {
+              "value": "{st.border.radius.md}",
+              "type": "borderRadius"
+            },
+            "lg": {
+              "value": "{st.border.radius.lg}",
+              "type": "borderRadius"
+            },
+            "xl": {
+              "value": "{st.border.radius.xl}",
+              "type": "borderRadius"
+            }
+          }
+        }
       }
     },
     "borderWidth": {
@@ -2860,6 +4137,32 @@
         "outlined": {
           "value": "{borderWidth.xs}",
           "type": "borderWidth"
+        }
+      },
+      "st": {
+        "border": {
+          "width": {
+            "xs": {
+              "value": "{st.border.width.xs}",
+              "type": "borderWidth"
+            },
+            "sm": {
+              "value": "{st.border.width.sm}",
+              "type": "borderWidth"
+            },
+            "md": {
+              "value": "{st.border.width.md}",
+              "type": "borderWidth"
+            },
+            "lg": {
+              "value": "{st.border.width.lg}",
+              "type": "borderWidth"
+            },
+            "xl": {
+              "value": "{st.border.width.xl}",
+              "type": "borderWidth"
+            }
+          }
         }
       }
     },
@@ -3552,6 +4855,82 @@
         "default": {
           "value": "{typography.body.body14}",
           "type": "typography"
+        }
+      }
+    },
+    "boxShadow": {
+      "st": {
+        "boxshadow": {
+          "brand": {
+            "default": {
+              "value": "{st.boxshadow.brand.default}",
+              "type": "boxShadow"
+            },
+            "hover": {
+              "value": "{st.boxshadow.brand.hover}",
+              "type": "boxShadow"
+            }
+          },
+          "secondary": {
+            "default": {
+              "value": "{st.boxshadow.success.default}",
+              "type": "boxShadow"
+            },
+            "hover": {
+              "value": "{st.boxshadow.secondary.hover}",
+              "type": "boxShadow"
+            }
+          },
+          "tertiary": {
+            "default": {
+              "value": "{st.boxshadow.tertiary.default}",
+              "type": "boxShadow"
+            },
+            "hover": {
+              "value": "{st.boxshadow.tertiary.hover}",
+              "type": "boxShadow"
+            }
+          },
+          "info": {
+            "default": {
+              "value": "{st.boxshadow.info.default}",
+              "type": "boxShadow"
+            },
+            "hover": {
+              "value": "{st.boxshadow.info.hover}",
+              "type": "boxShadow"
+            }
+          },
+          "error": {
+            "default": {
+              "value": "{st.boxshadow.error.default}",
+              "type": "boxShadow"
+            },
+            "hover": {
+              "value": "{st.boxshadow.error.hover}",
+              "type": "boxShadow"
+            }
+          },
+          "warning": {
+            "default": {
+              "value": "{st.boxshadow.warning.default}",
+              "type": "boxShadow"
+            },
+            "hover": {
+              "value": "{st.boxshadow.warning.hover}",
+              "type": "boxShadow"
+            }
+          },
+          "success": {
+            "default": {
+              "value": "{st.boxshadow.success.default}",
+              "type": "boxShadow"
+            },
+            "hover": {
+              "value": "{st.boxshadow.success.hover}",
+              "type": "boxShadow"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Contains the addition of about 84 new tokens:

bg.base
bg.layer
bg.overlayer

bg.brand.active
bg.brand.hover
bg.brand.default

bg.secondary.active
bg.secondary.hover
bg.secondary.default

bg.tertiary.active
bg.tertiary.hover 
bg.tertiary.default

bg.success.active
bg.success.hover
 bg.success.default

bg.error.active
bg.error.hover
bg.error.default

bg.warning.active
bg.warning.hover
 bg.warning.default

bg.info.active
bg.info.hover
 bg.info.default

bg.ghost.active
bg.ghost.hover
bg.ghost.default

bg.filled

border.hover
border.default
border.error
border.warning
border.info
border.success

border.brand.active
border.brand.hover
border.brand.default

border.secondary.active
border.secondary.hover
border.secondary.default

border.tertiary.active
border.tertiary.hover
border.tertiary.default
 
text.error
text.warning
text.info
text.brand
text.secondary
text.tertiary
 
st.border.width.xs
st.border.width.sm
st.border.width.md
st.border.width.lg
st.border.width.xl

st.boxshadow.brand.default
st.boxshadow.brand.hover

st.boxshadow.secondary.default
st.boxshadow.secondary.hover

st.boxshadow.tertiary.default
st.boxshadow.tertiary.hover

st.boxshadow.info.default
st.boxshadow.info.hover

st.boxshadow.success.default
st.boxshadow.success.hover

st.boxshadow.error.default
st.boxshadow.error.hover

st.boxshadow.warning.default
st.boxshadow.warning.hover 
 
st.color.brand.50
st.color.brand.100
st.color.brand.100
st.color.brand.200
st.color.brand.200
st.color.brand.300
st.color.brand.400
st.color.brand.500
st.color.brand.600
st.color.brand.700
st.color.brand.800
st.color.brand.900
 
st.border.radius.xs
st.border.radius.sm
st.border.radius.md
st.border.radius.lg
st.border.radius.xl

Some notes:
* the original plan was to have the following naming schema: "color.bg, color.bg.hover, color.bg.active...", however due to the way that this tokens are stored in json this is not possible, as it would be stored under subcategory, basically: {color: {hover: "value", active: "value", default: "value"}, hence it's needed to add default at end.
* The original plan was to have all the system tokens named st.color.{rest-of-token}, but I talked with Illija and this feels redundant for color tokens, as that's a lot to type of and the reference tokens will always be {color}{colorShade}, hence this prefix was removed
* It was however kept for st.color.brand.{shade}, to distinguish them from the normal color reference tokens
* I left out the opacity tokens as I started having doubts about them, should they perhaps be global tokens instead of system tokens?