### PR TITLE
chore(framework): move dep react-router-dom

### DIFF
--- a/framework/package.json
+++ b/framework/package.json
@@ -73,7 +73,9 @@
     "react-virtualized": "^9.22.3",
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
-    "style-dictionary": "^3.7.1"
+    "style-dictionary": "^3.7.1",
+    "react-router-dom": "5.2.0",
+    "@types/react-router-dom": "^5.3.2"
   },
   "devDependencies": {
     "@esbuild-kit/cjs-loader": "^2.4.2",
@@ -90,7 +92,6 @@
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
     "@types/react-input-mask": "3.0.2",
-    "@types/react-router-dom": "^5.3.2",
     "@vitejs/plugin-react-refresh": "^1.3.6",
     "chai": "^4.3.7",
     "esbuild": "^0.17.10",
@@ -100,7 +101,6 @@
     "mocha": "^10.2.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
-    "react-router-dom": "5.2.0",
     "rollup": "^3.17.2",
     "rollup-plugin-dts": "^5.2.0",
     "rollup-plugin-esbuild": "^5.0.0",


### PR DESCRIPTION
react-router-dom is currently used by components such as Navbaritem so it should be listed as normal package dependency for now