### PR TITLE
fix(northlight/framework): searchbar types

### DIFF
--- a/framework/lib/components/search-bar/types.ts
+++ b/framework/lib/components/search-bar/types.ts
@@ -26,8 +26,8 @@ export interface SearchBarProps<T extends SearchBarOptionType>
   > {
   value?: T | T[]
   onChange?: (val: any, event: ActionMeta<T>) => void
-  onAdd?: (val: unknown) => void
-  onRemove?: (val: unknown) => void
+  onAdd?: (val: T['value']) => void
+  onRemove?: (val: T['value']) => void
   size?: Size
   'data-testid'?: string
   debouncedWaitTime?: number


### PR DESCRIPTION
the types for onAdd and onRemove gave ts error because of the unknown type, hence I changed it to a generic type.