### PR TITLE
fix(framework): add type for custom option

### DIFF
--- a/framework/lib/components/select/types.ts
+++ b/framework/lib/components/select/types.ts
@@ -36,6 +36,7 @@ export interface SelectProps<T>
   | undefined
   /** Custom icon that will be put to the faremost right of the component */
   icon?: ComponentType<any>
+  customOption?: ((option: T) => JSX.Element) | null
 }
 
 export type SelectFieldProps<T> = Omit<SelectProps<T>, 'onChange'> &


### PR DESCRIPTION
added missing type for customOption so that it can be used in typescript files.