### PR TITLE
fix: remove overflow:scroll on html element

### DIFF
--- a/framework/lib/theme/index.ts
+++ b/framework/lib/theme/index.ts
@@ -33,7 +33,6 @@ const overrides: ThemeOverride = {
     global: {
       html: {
         'scroll-behavior': 'smooth',
-        overflow: 'scroll',
       },
       body: {
         height: '100%',


### PR DESCRIPTION
This fixes an issue with the theme where the scrollbars placeholders were always visible on the page regardless of scrolling or not.