### PR TITLE
chore(framework): added isClearable for range calendar

### DIFF
--- a/framework/lib/components/date-picker/components/calendar/range-calendar.tsx
+++ b/framework/lib/components/date-picker/components/calendar/range-calendar.tsx
@@ -53,7 +53,7 @@ export const RangeCalendar = (props: RangeCalendarProps) => {
     ref
   )
 
-  const { fiscalStartMonth, handleClose, resetDate } = props
+  const { fiscalStartMonth, handleClose, resetDate, isClearable = true } = props
 
   return (
     <Box { ...calendarProps } ref={ ref } __css={ rangeCalendarContainer }>
@@ -105,9 +105,11 @@ export const RangeCalendar = (props: RangeCalendarProps) => {
                 />
                 <AdjustRange state={ state } adjust="end" />
                 <HStack alignSelf="end" pt="2">
-                  <Button onClick={ resetDate } variant="ghost" size="sm">
-                    Clear
-                  </Button>
+                  { isClearable && (
+                    <Button onClick={ resetDate } variant="ghost" size="sm">
+                      Clear
+                    </Button>
+                  ) }
                   <Button variant="brand" onClick={ handleClose } size="sm">
                     Save
                   </Button>

--- a/framework/lib/components/date-picker/components/calendar/simple-range-calendar.tsx
+++ b/framework/lib/components/date-picker/components/calendar/simple-range-calendar.tsx
@@ -35,7 +35,7 @@ export const SimpleRangeCalendar = (props: RangeCalendarProps) => {
     ref
   )
 
-  const { fiscalStartMonth, handleClose, resetDate } = props
+  const { fiscalStartMonth, handleClose, resetDate, isClearable = true } = props
 
   return (
     <Box { ...calendarProps } ref={ ref } __css={ rangeCalendarContainer }>
@@ -64,9 +64,11 @@ export const SimpleRangeCalendar = (props: RangeCalendarProps) => {
             <Stack h="full" justify="space-between">
               <RangeCalendarGrid state={ state } locale={ locale } />
               <HStack alignSelf="end" pt="2">
-                <Button onClick={ resetDate } variant="ghost" size="sm">
-                  Clear
-                </Button>
+                { isClearable && (
+                  <Button onClick={ resetDate } variant="ghost" size="sm">
+                    Clear
+                  </Button>
+                ) }
                 <Button variant="brand" onClick={ handleClose } size="sm">
                   Save
                 </Button>

--- a/framework/lib/components/date-picker/components/calendar/types.ts
+++ b/framework/lib/components/date-picker/components/calendar/types.ts
@@ -5,6 +5,7 @@ export interface RangeCalendarProps extends AriaRangeCalendarProps<DateValue> {
   resetDate: () => void
   handleClose: () => void
   fiscalStartMonth: number
+  isClearable: boolean
 }
 
 export type CalendarProps = AriaCalendarProps<DateValue>

--- a/framework/lib/components/date-picker/date-picker-field/date-range-picker-field.tsx
+++ b/framework/lib/components/date-picker/date-picker-field/date-range-picker-field.tsx
@@ -22,6 +22,7 @@ export const DateRangePickerField = ({
   validate,
   firstDayOfWeek = 'monday',
   onChange: onChangeCallback = identity,
+  isClearable = true,
   ...rest
 }: DateRangePickerFieldProps) => {
   const { setValue, setError, trigger } = useFormContext<FormBody>()
@@ -66,6 +67,7 @@ export const DateRangePickerField = ({
           minValue={ minValue }
           maxValue={ maxValue }
           validationState={ errors.name ? 'invalid' : 'valid' }
+          isClearable={ isClearable }
           { ...(rest as any) }
         />
       ) }

--- a/framework/lib/components/date-picker/date-picker/date-range-picker.tsx
+++ b/framework/lib/components/date-picker/date-picker/date-range-picker.tsx
@@ -182,6 +182,7 @@ export const DateRangePicker = (props: DateRangePickerProps) => {
                 resetDate={ resetDate }
                 handleClose={ handleClose }
                 fiscalStartMonth={ fiscalStartMonth || 0 }
+                isClearable={ isClearable }
               />
             ) }
             {
@@ -191,6 +192,7 @@ export const DateRangePicker = (props: DateRangePickerProps) => {
               resetDate={ resetDate }
               handleClose={ handleClose }
               fiscalStartMonth={ fiscalStartMonth || 0 }
+              isClearable={ isClearable }
             />
             ) }
           </FocusScope>

--- a/framework/package.json
+++ b/framework/package.json
@@ -22,7 +22,8 @@
     "lint": "eslint --ext ts,tsx lib/ test/",
     "prepublishOnly": "yarn clean && yarn transpile",
     "test": "yarn mtft test",
-    "transpile": "rollup -c"
+    "transpile": "rollup -c",
+    "watch": "yarn transpile -w"
   },
   "dependencies": {
     "@chakra-ui/clickable": "^2.0.14",


### PR DESCRIPTION
added isClearable prop for range calendar. Reason for this is that we have clear button inside calendar picker. Even though we have isClearable false or true , it was always visible.

![image](https://github.com/mediatool/northlight/assets/90190447/700490df-7056-4308-bb3b-41e32220a1e6)
