### PR TITLE
fix: configure nx to transpile before dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To start up a local environment of the Northlight UI framework docs:
 2. cd into the directory
 3. run `yarn`
 4. cd into `/docs`
-6. run `yarn dev`
+6. run `yarn nx dev`
 
 This will spin up a local environment at localhost:3008 (or the first available port after that)
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "start": "yarn vite",
-    "dev": "yarn build:reference && yarn start",
+    "dev": "yarn start",
     "build": "vite build",
     "transpile": "node src/reference/utils/generate-doc.mjs",
     "lint": "yarn tsc --noEmit && eslint --ext ts,tsx src"

--- a/nx.json
+++ b/nx.json
@@ -23,6 +23,9 @@
     "build": {
       "dependsOn": ["transpile"]
     },
+    "dev": {
+      "dependsOn": ["transpile"]
+    },
     "transpile": {
       "dependsOn": ["^transpile"],
       "outputs": [


### PR DESCRIPTION
With this, you should start the docs server running `yarn nx dev`.