### PR TITLE
chore(northlight): new labelPosition prop for SwitchField

### DIFF
--- a/framework/lib/components/switch/switch-field.tsx
+++ b/framework/lib/components/switch/switch-field.tsx
@@ -4,12 +4,25 @@ import { SwitchFieldProps } from './types'
 import { Field } from '../form'
 import { Switch } from './switch'
 import { Box } from '../box'
+import { Flex } from '../flex'
+import { Label } from '../typography'
 
 /**
  * The switch component wrapped in a <Field />
  * meant to be used only inside <Form />
  * @see switch
  * @see {@link https://northlight.dev/reference/switch-field}
+* @example (Example)
+ * ## Basic
+ * (?
+ * <Form initialValues={{name: ''}}>
+ *  <SwitchField
+ *   name="terms"
+ *   label="I agree to the Terms & Conditions"
+ *   labelPosition="left"
+ *  />
+ * </Form>
+ * ?)
  *
  */
 export const SwitchField = ({
@@ -19,24 +32,34 @@ export const SwitchField = ({
   validate,
   onChange: onChangeCallback = identity,
   direction = 'row',
+  labelPosition = 'right',
   ...rest
 }: SwitchFieldProps) => (
   <Box w={ label ? 'full' : 'fit-content' }>
     <Field
       name={ name }
-      label={ label }
+      label=""
       isRequired={ isRequired }
       direction={ direction }
       validate={ validate }
     >
       { ({ onChange, value }) => (
-        <Switch
-          name={ name }
-          onChange={ (e) => { onChange(e); onChangeCallback(e) } }
-          value={ value }
-          data-testid="switch-field-test-id"
-          { ...rest }
-        />
+        <Flex
+          gap={ 2 }
+          direction={ labelPosition === 'left' ? 'row-reverse' : 'row' }
+        >
+          <Switch
+            name={ name }
+            onChange={ (e) => {
+              onChange(e)
+              onChangeCallback(e)
+            } }
+            value={ value }
+            data-testid="switch-field-test-id"
+            { ...rest }
+          />
+          { label && <Label htmlFor={ name }>{ label }</Label> }
+        </Flex>
       ) }
     </Field>
   </Box>

--- a/framework/lib/components/switch/types.ts
+++ b/framework/lib/components/switch/types.ts
@@ -17,4 +17,5 @@ export type SwitchFieldProps =
     validate?: RegisterOptions
     isRequired?: boolean
     direction?: StackDirection
+    labelPosition?: 'left' | 'right'
   }


### PR DESCRIPTION
- Fixes the issue with the strange spacing between <Switch> and the generated <Label> 
- The new prop `labelPosition` gives an opportunity to select whether you want the label to be on the "left" or "right" of the <Switch>
- Basic usage added to the reference page

closes: DEV-8557