### PR TITLE
feat(northlight): datePicker-calendar fiscalStartDay prop

### DIFF
--- a/docs/src/docs/pages/date-range-picker-page/index.tsx
+++ b/docs/src/docs/pages/date-range-picker-page/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Code, DateRangePickerField, Divider, Form, HStack, P, Stack } from '@northlight/ui'
+import { Code, DateRangePickerField, Divider, Form, HStack, P, Stack, Text } from '@northlight/ui'
 import { Page } from '../../components'
 
 const DateRangePickerPage = () => (
@@ -30,7 +30,7 @@ const DateRangePickerPage = () => (
             <Divider />
             <P>
               You can pass on custom formatting to date-picker via{ ' ' }
-              <b>dateFormat</b>
+              <Text as="b">dateFormat</Text>
             </P>
             <DateRangePickerField
               name="formattedDate"
@@ -70,14 +70,14 @@ const DateRangePickerPage = () => (
             </HStack>
             <P>
               You can adjust the custom company fiscal year by setting the { ' ' }
-              <b>fiscalStartMonth</b> to the number of the month, counting
-              after January,
-              ex fiscalStartMonth=2 starts the year at March
+              <Text as="b">fiscalStartMonth</Text> and <Text as="b">fiscalStartDay</Text> to the number of the month and the day counting after January,<br />
+              ex: <Code>fiscalStartMonth=2</Code> starts the year at March
             </P>
             <DateRangePickerField
               name="fiscal-date"
               label="Pick a date"
-              fiscalStartMonth={ 4 }
+              fiscalStartMonth={ 2 }
+              fiscalStartDay={ 18 }
             />
             <P>
               Notice that QN changed to FQN and that two options, "this fiscal
@@ -89,7 +89,7 @@ const DateRangePickerPage = () => (
               week day labels, can be either monday or sunday
             </P>
             <P>
-              <b>isClearable</b>
+              <Text as="b">isClearable</Text>
               - A prop that when true shows a cross button
               to the right of the date field
               that resets the date range. It also has a clear button on calendar UI.

--- a/framework/lib/components/date-picker/components/calendar/quick-navigation/get-quick-select-options.ts
+++ b/framework/lib/components/date-picker/components/calendar/quick-navigation/get-quick-select-options.ts
@@ -1,4 +1,5 @@
 import {
+  CalendarDate,
   endOfMonth,
   endOfWeek,
   endOfYear,
@@ -12,9 +13,22 @@ import { RangeCalendarState } from '@react-stately/calendar'
 export const getQuickSelectOptions = (
   state: RangeCalendarState,
   locale: string,
-  fiscalStartMonth: number
+  fiscalStartMonth: number,
+  fiscalStartDay: number
 ) => {
   const thisDay = today(state.timeZone)
+
+  const startOfMonthWithDays = (date: CalendarDate,
+    { months, days }: { months: number, days: number }) => {
+    const start = date.add({ months }).set({ day: days })
+    return start
+  }
+
+  const endOfMonthWithDays = (date: CalendarDate,
+    { months, days }:{ months: number, days: number }) => {
+    const end = date.add({ months }).set({ day: days }).subtract({ days: 1 })
+    return end
+  }
 
   const thisWeek = {
     value: {
@@ -98,11 +112,11 @@ export const getQuickSelectOptions = (
 
   const thisFiscalYear = {
     value: {
-      start: startOfMonth(
-        startOfYear(thisDay).add({ months: fiscalStartMonth })
+      start: startOfMonthWithDays(
+        startOfYear(thisDay), { months: fiscalStartMonth, days: fiscalStartDay }
       ),
-      end: endOfMonth(
-        startOfYear(thisDay).add({ months: fiscalStartMonth + 11 })
+      end: endOfMonthWithDays(
+        startOfYear(thisDay), { months: fiscalStartMonth + 11, days: fiscalStartDay }
       ),
     },
     label: 'This Fiscal Year',
@@ -110,15 +124,13 @@ export const getQuickSelectOptions = (
 
   const lastFiscalYear = {
     value: {
-      start: startOfMonth(
-        startOfYear(thisDay)
-          .add({ months: fiscalStartMonth })
-          .subtract({ years: 1 })
+      start: startOfMonthWithDays(
+        startOfYear(thisDay).subtract({ years: 1 }),
+        { months: fiscalStartMonth, days: fiscalStartDay - 1 }
       ),
-      end: endOfMonth(
-        startOfYear(thisDay)
-          .add({ months: fiscalStartMonth + 11 })
-          .subtract({ years: 1 })
+      end: endOfMonthWithDays(
+        startOfYear(thisDay).subtract({ years: 1 }),
+        { months: fiscalStartMonth + 11, days: fiscalStartDay }
       ),
     },
     label: 'Last Fiscal Year',
@@ -126,11 +138,11 @@ export const getQuickSelectOptions = (
 
   const F1 = {
     value: {
-      start: startOfMonth(
-        startOfYear(thisDay).add({ months: fiscalStartMonth })
+      start: startOfMonthWithDays(
+        startOfYear(thisDay), { months: fiscalStartMonth, days: fiscalStartDay }
       ),
-      end: endOfMonth(
-        startOfYear(thisDay).add({ months: fiscalStartMonth + 2 })
+      end: endOfMonthWithDays(
+        startOfYear(thisDay), { months: fiscalStartMonth + 2, days: fiscalStartDay }
       ),
     },
     label: fiscalStartMonth === 0 ? 'Q1' : 'FQ1',
@@ -138,11 +150,11 @@ export const getQuickSelectOptions = (
 
   const F2 = {
     value: {
-      start: startOfMonth(
-        startOfYear(thisDay).add({ months: fiscalStartMonth + 3 })
+      start: startOfMonthWithDays(
+        startOfYear(thisDay), { months: fiscalStartMonth + 3, days: fiscalStartDay }
       ),
-      end: endOfMonth(
-        startOfYear(thisDay).add({ months: fiscalStartMonth + 5 })
+      end: endOfMonthWithDays(
+        startOfYear(thisDay), { months: fiscalStartMonth + 5, days: fiscalStartDay }
       ),
     },
     label: fiscalStartMonth === 0 ? 'Q2' : 'FQ2',
@@ -150,11 +162,11 @@ export const getQuickSelectOptions = (
 
   const F3 = {
     value: {
-      start: startOfMonth(
-        startOfYear(thisDay).add({ months: fiscalStartMonth + 6 })
+      start: startOfMonthWithDays(
+        startOfYear(thisDay), { months: fiscalStartMonth + 6, days: fiscalStartDay }
       ),
-      end: endOfMonth(
-        startOfYear(thisDay).add({ months: fiscalStartMonth + 8 })
+      end: endOfMonthWithDays(
+        startOfYear(thisDay), { months: fiscalStartMonth + 8, days: fiscalStartDay }
       ),
     },
     label: fiscalStartMonth === 0 ? 'Q3' : 'FQ3',
@@ -162,11 +174,11 @@ export const getQuickSelectOptions = (
 
   const F4 = {
     value: {
-      start: startOfMonth(
-        startOfYear(thisDay).add({ months: fiscalStartMonth + 9 })
+      start: startOfMonthWithDays(
+        startOfYear(thisDay), { months: fiscalStartMonth + 9, days: fiscalStartDay }
       ),
-      end: endOfMonth(
-        startOfYear(thisDay).add({ months: fiscalStartMonth + 11 })
+      end: endOfMonthWithDays(
+        startOfYear(thisDay), { months: fiscalStartMonth + 11, days: fiscalStartDay }
       ),
     },
     label: fiscalStartMonth === 0 ? 'Q4' : 'FQ4',

--- a/framework/lib/components/date-picker/components/calendar/quick-navigation/quick-select.tsx
+++ b/framework/lib/components/date-picker/components/calendar/quick-navigation/quick-select.tsx
@@ -15,12 +15,13 @@ const seperator = `1px solid ${palette.gray['100']}`
 export const QuickSelect = ({
   state,
   fiscalStartMonth = 0,
+  fiscalStartDay = 0,
   updateVisibleRange,
   locale = '',
   height = 'xs',
 }: QuickSelectProps) => {
   const { quickDates, fiscalQuarters } = useMemo(
-    () => getQuickSelectOptions(state, locale, fiscalStartMonth),
+    () => getQuickSelectOptions(state, locale, fiscalStartMonth, fiscalStartDay),
     []
   )
 

--- a/framework/lib/components/date-picker/components/calendar/quick-navigation/types.ts
+++ b/framework/lib/components/date-picker/components/calendar/quick-navigation/types.ts
@@ -5,6 +5,7 @@ import { ComponentType } from 'react'
 export interface QuickSelectProps {
   state: RangeCalendarState
   fiscalStartMonth: number
+  fiscalStartDay?: number
   updateVisibleRange: () => void
   locale: string
   height?: string

--- a/framework/lib/components/date-picker/components/calendar/range-calendar.tsx
+++ b/framework/lib/components/date-picker/components/calendar/range-calendar.tsx
@@ -53,7 +53,7 @@ export const RangeCalendar = (props: RangeCalendarProps) => {
     ref
   )
 
-  const { fiscalStartMonth, handleClose, resetDate, isClearable = true } = props
+  const { fiscalStartMonth, fiscalStartDay, handleClose, resetDate, isClearable = true } = props
 
   return (
     <Box { ...calendarProps } ref={ ref } __css={ rangeCalendarContainer }>
@@ -64,6 +64,7 @@ export const RangeCalendar = (props: RangeCalendarProps) => {
             updateVisibleRange={ () => setUpdateRange(true) }
             locale={ locale }
             fiscalStartMonth={ fiscalStartMonth }
+            fiscalStartDay={ fiscalStartDay }
           />
           <Stack>
             <HStack spacing={ 2 } alignSelf="center">

--- a/framework/lib/components/date-picker/components/calendar/simple-range-calendar.tsx
+++ b/framework/lib/components/date-picker/components/calendar/simple-range-calendar.tsx
@@ -35,7 +35,7 @@ export const SimpleRangeCalendar = (props: RangeCalendarProps) => {
     ref
   )
 
-  const { fiscalStartMonth, handleClose, resetDate, isClearable = true } = props
+  const { fiscalStartMonth, fiscalStartDay, handleClose, resetDate, isClearable = true } = props
 
   return (
     <Box { ...calendarProps } ref={ ref } __css={ rangeCalendarContainer }>
@@ -46,6 +46,7 @@ export const SimpleRangeCalendar = (props: RangeCalendarProps) => {
             updateVisibleRange={ () => {} }
             locale={ locale }
             fiscalStartMonth={ fiscalStartMonth }
+            fiscalStartDay={ fiscalStartDay }
             height="72"
           />
           <Stack>

--- a/framework/lib/components/date-picker/components/calendar/types.ts
+++ b/framework/lib/components/date-picker/components/calendar/types.ts
@@ -5,6 +5,7 @@ export interface RangeCalendarProps extends AriaRangeCalendarProps<DateValue> {
   resetDate: () => void
   handleClose: () => void
   fiscalStartMonth: number
+  fiscalStartDay?: number
   isClearable: boolean
 }
 

--- a/framework/lib/components/date-picker/date-picker/date-range-picker.tsx
+++ b/framework/lib/components/date-picker/date-picker/date-range-picker.tsx
@@ -54,17 +54,19 @@ const parseValue = (value: any) => {
  * ?)
  *
  * @example (Example)
- * ### Another example
+ * ## Sophisticated example
+ * The `DateRangePickerField` can have **fiscalStartMonth** and **fiscalStartDay** as a `number`
  * (?
  * <Form initialValues={{date: null}}>
   * <DateRangePickerField
   * name="date"
-  * mode="simple"
+  * mode="advanced"
   * variant="filled"
-  * fiscalStarMonth={3}
+  * fiscalStartMonth={3}
+  * fiscalStartDay={5}
   * dateFormat="mm|dd-yyyy"
   * minValue="2023-01-01"
-  * maxValue="2024-01-01"
+  * maxValue="2028-01-01"
   * />
  * </Form>
  * ?)
@@ -77,6 +79,7 @@ export const DateRangePicker = (props: DateRangePickerProps) => {
     isInvalid = false,
     dateFormat,
     fiscalStartMonth,
+    fiscalStartDay,
     mode = 'advanced',
     variant = 'outline',
     onChange: onChangeCallback = identity,
@@ -182,6 +185,7 @@ export const DateRangePicker = (props: DateRangePickerProps) => {
                 resetDate={ resetDate }
                 handleClose={ handleClose }
                 fiscalStartMonth={ fiscalStartMonth || 0 }
+                fiscalStartDay={ fiscalStartDay || 0 }
                 isClearable={ isClearable }
               />
             ) }
@@ -192,6 +196,7 @@ export const DateRangePicker = (props: DateRangePickerProps) => {
               resetDate={ resetDate }
               handleClose={ handleClose }
               fiscalStartMonth={ fiscalStartMonth || 0 }
+              fiscalStartDay={ fiscalStartDay || 0 }
               isClearable={ isClearable }
             />
             ) }

--- a/framework/lib/components/date-picker/types.ts
+++ b/framework/lib/components/date-picker/types.ts
@@ -41,6 +41,7 @@ export interface DateRangePickerProps
   minValue?: string | undefined
   maxValue?: string | undefined
   fiscalStartMonth?: number
+  fiscalStartDay?: number
   mode?: DatePickerMode
 }
 
@@ -57,6 +58,7 @@ export interface DatePickerFieldProps
   onChange?: (date: DateValue) => void
   isClearable?: boolean
   fiscalStartMonth?: number
+  fiscalStartDay?: number
 }
 
 export interface DateRangePickerFieldProps extends Omit<DatePickerFieldProps, 'onChange'> {


### PR DESCRIPTION
Adds a new prop fiscalStartDay as prop to all the calendars/date pickers, which solves the issue of having no exact starting day from the fiscal year settings  when creating a new plan 

closes: DEV-8742