### PR TITLE
fix(framework): change selectfieldtype

### DIFF
--- a/framework/lib/components/select/select-field.tsx
+++ b/framework/lib/components/select/select-field.tsx
@@ -10,7 +10,7 @@ import { IconButton } from '../icon-button'
 import { Icon } from '../icon'
 import { InputGroupWrapper } from '../../internal-components/input-group-wrapper/input-group-wrapper'
 
-export function SelectField<T extends Option> ({
+export function SelectField<T extends Option, K extends boolean = false> ({
   name,
   label,
   options,
@@ -23,7 +23,7 @@ export function SelectField<T extends Option> ({
   inputLeftElement,
   inputRightElement,
   ...rest
-}: SelectFieldProps<T>) {
+}: SelectFieldProps<T, K>) {
   return (
     <Field
       name={ name }
@@ -49,7 +49,7 @@ export function SelectField<T extends Option> ({
                     ? values.map((item: any) => item.value)
                     : values.value
                 )
-                onChangeCallback(values as T | T[], event)
+                onChangeCallback(values as K extends true ? T[] : T, event)
               } }
               value={
               value

--- a/framework/lib/components/select/types.ts
+++ b/framework/lib/components/select/types.ts
@@ -39,13 +39,13 @@ export interface SelectProps<T>
   customOption?: ((option: T) => JSX.Element) | null
 }
 
-export type SelectFieldProps<T> = Omit<SelectProps<T>, 'onChange'> &
-InputFieldProps & {
-  onChange?: (val: T | T[], event: ActionMeta<T>) => void
+export type SelectFieldProps<T, K extends boolean = false> = Omit<SelectProps<T>, 'onChange' | 'isMulti'> &
+Omit<InputFieldProps, 'isMulti'> & {
+  onChange?: (val: K extends true ? T[] : T, event: ActionMeta<T>) => void
   direction?: StackDirection
   name: string
   label: string
   validate?: RegisterOptions
   isRequired?: boolean
-  isMulti?: boolean
+  isMulti?: K
 }


### PR DESCRIPTION
when asserting type of event passed in callback to onchange prop in selectfield it would not be compatible with the expected type. change to account for cases of ismulti is false and true respectively