### PR TITLE
chore(northlight): new button variant brandSubdued

### DIFF
--- a/framework/lib/components/button/types.ts
+++ b/framework/lib/components/button/types.ts
@@ -1,6 +1,6 @@
 import { ButtonProps as ChakraButtonProps } from '@chakra-ui/react'
 
-export type ButtonVariants = 'default' | 'danger' | 'success' | 'brand' | 'link' | 'ghost'
+export type ButtonVariants = 'default' | 'danger' | 'success' | 'brand' | 'brandSubdued' | 'link' | 'ghost'
 export interface ButtonProps extends ChakraButtonProps {
   variant?: ButtonVariants
 }

--- a/framework/lib/theme/components/button/index.ts
+++ b/framework/lib/theme/components/button/index.ts
@@ -84,6 +84,22 @@ export const Button: ComponentSingleStyleConfig = {
         bgColor: color.background.button['brand-active'],
       },
     }),
+    brandSubdued: ({ theme: { colors: color } }) => ({
+      color: color.text.button.link,
+      bgColor: color.background.button.ghost,
+      _hover: {
+        bg: color.background.button.brand,
+        color: color.text.inverted,
+        _disabled: {
+          bgColor: color.background.button.ghost,
+          color: color.text.button.link,
+        },
+      },
+      _active: {
+        bg: color.background.button['brand-hover'],
+        color: color.text.inverted,
+      },
+    }),
     link: ({ theme: { colors: color } }) => ({
       textDecoration: 'underline',
       color: color.text.button.link,


### PR DESCRIPTION
Buttons now have a brandSubdued variant, which is basically an inverted brand button, This applies to all buttons across the design system

closes: DEV-7888