### PR TITLE
fix(framework): reduce zIndex for datePicker controls

### DIFF
--- a/framework/lib/components/date-picker/date-picker/date-picker.tsx
+++ b/framework/lib/components/date-picker/date-picker/date-picker.tsx
@@ -108,7 +108,7 @@ export const DatePicker = (props: DatePickerProps) => {
                 />
               </Box>
             </StyledField>
-            <InputRightElement>
+            <InputRightElement zIndex={ 0 }>
               <Trigger
                 { ...buttonProps }
                 isDisabled={ isDisabled }


### PR DESCRIPTION
@ilija- @magnusohlin This is a "dirty" fix. Can potentially be merged now to fix the symptom.

---

This commit fixes the issue when DatePicker controls would overlap the multi-select dropdown. Since, the datePicker controls should be on the same layer as the input, the zIndex value was reduced to 0.