### PR TITLE
chore(framework): export StackProps interface

### DIFF
--- a/framework/lib/components/stack/index.ts
+++ b/framework/lib/components/stack/index.ts
@@ -4,3 +4,4 @@ export {
   VStack,
   StackDivider,
 } from '@chakra-ui/react'
+export type { StackProps } from '@chakra-ui/react'


### PR DESCRIPTION
This commit exports the StackProps interface,
which is used a props for HStack, VStack and similar.

Export of props interfaces is one of the core principles of good Typescript code. It's essential Needed for good integration with 3rd parties.