### PR TITLE
fix(framework): expose styling props for Field

### DIFF
--- a/framework/lib/components/form/field.tsx
+++ b/framework/lib/components/form/field.tsx
@@ -109,6 +109,7 @@ export function Field<
   noLabelConnection = false,
   validate,
   control: passedControl,
+  ...rest
 }: FieldProps<FormValues, FieldName>) {
   const methods = useFormContext<FormValues>()
   const { formState: { errors } } = methods
@@ -122,6 +123,7 @@ export function Field<
         spacing="auto"
         direction={ direction }
         alignItems={ direction === 'column' ? 'stretch' : 'center' }
+        { ...rest }
       >
         { label && (
           <FormLabel htmlFor={ noLabelConnection ? undefined : name } mb={ 1 }>

--- a/framework/lib/components/form/types.ts
+++ b/framework/lib/components/form/types.ts
@@ -12,7 +12,7 @@ import {
   SetValueConfig,
   UseFormProps,
 } from 'react-hook-form'
-import { StackDirection } from '@chakra-ui/react'
+import { StackDirection, StackProps } from '@chakra-ui/react'
 
 export type UseFormReturn<T extends FieldValues> = RHFUseFormReturn<T>
 
@@ -28,7 +28,7 @@ export type SetValueOptionsType = Maybe<SetValueConfig>
 export interface FieldProps<
   FormValues extends FieldValues = FieldValues,
   FieldName extends FieldPath<FormValues> = FieldPath<FormValues>
-> {
+> extends Omit<StackProps, 'children'> {
   name: FieldName
   /** Label displayed as text beside or under/over
    * (depending on direction prop) over children. Recommended for accesibility */


### PR DESCRIPTION
This commit exposes styling props for the Field
component, which allows manual and custom styling
when using the component in a real application.

This is implemented by applying non-used component props to the Stack component in use, allowing for flexible integration with other layout elements.

--
https://app.clickup.com/t/758254/DEV-9228