### PR TITLE
fix(framework): center text in flip button

### DIFF
--- a/framework/lib/components/flip-button/flip-button.tsx
+++ b/framework/lib/components/flip-button/flip-button.tsx
@@ -163,7 +163,7 @@ export const FlipButton = (props: FlipButtonProps) => {
     })
     : (
       <HStack
-        spacing={ isSelected || icon ? 2 : 0 }
+        spacing={ (isSelected && iconPlacement !== 'none') || icon ? 2 : 0 }
         sx={ mergeAll([ button, isFocused ? focusStyles : {}, { flexDirection: iconPlacement === 'left' ? 'row' : 'row-reverse' } ]) }
         aria-checked={ isSelected }
         aria-disabled={ isDisabled }


### PR DESCRIPTION
when used with no icon text would be shifted to the right.