### PR TITLE
fix(framework): fix broken search bar northlight docs

### DIFF
--- a/framework/lib/components/search-bar/get-components.tsx
+++ b/framework/lib/components/search-bar/get-components.tsx
@@ -11,7 +11,35 @@ import { HStack } from '../stack'
 import { Icon } from '../icon'
 import { SearchBarOptionType } from './types'
 
-export function getComponents<T extends SearchBarOptionType> () {
+interface GetComponentsProps {
+  defaultControl?: boolean
+}
+
+export function getComponents<T extends SearchBarOptionType> ({
+  defaultControl = true,
+}: GetComponentsProps) {
+  const control = defaultControl
+    ? {}
+    : {
+      Control: ({
+        children,
+        ...props
+      }: ControlProps<T, boolean, GroupBase<T>>) =>
+        (props.selectProps.leftIcon ? (
+          <chakraComponents.Control { ...props }>
+            <HStack w="full" pl="2">
+              <Icon as={ props.selectProps.leftIcon } />
+              <HStack w="full" justify="space-between">
+                { children }
+              </HStack>
+            </HStack>
+          </chakraComponents.Control>
+        ) : (
+          <chakraComponents.Control { ...props }>
+            { children }
+          </chakraComponents.Control>
+        )),
+    }
   return {
     DropdownIndicator: (props: DropdownIndicatorProps<T>) =>
       (props.selectProps.icon ? (
@@ -39,20 +67,6 @@ export function getComponents<T extends SearchBarOptionType> () {
       ) : (
         <chakraComponents.MultiValueContainer { ...props } />
       )),
-    Control: ({ children, ...props }: ControlProps<T, boolean, GroupBase<T>>) =>
-      (props.selectProps.leftIcon ? (
-        <chakraComponents.Control { ...props }>
-          <HStack w="full" pl="2">
-            <Icon as={ props.selectProps.leftIcon } />
-            <HStack w="full" justify="space-between">
-              { children }
-            </HStack>
-          </HStack>
-        </chakraComponents.Control>
-      ) : (
-        <chakraComponents.Control { ...props }>
-          { children }
-        </chakraComponents.Control>
-      )),
+    ...control,
   }
 }

--- a/framework/lib/components/search-bar/search-bar.tsx
+++ b/framework/lib/components/search-bar/search-bar.tsx
@@ -49,7 +49,7 @@ export const SearchBar = forwardRef(
       isMulti,
       value: is(Array, value) ? value as T[] : [],
     })
-    const customComponents = getComponents<T>()
+    const customComponents = getComponents<T>({ defaultControl: true })
 
     const simpleFilter = (query: string) => (
       filter(

--- a/framework/lib/components/select/select.tsx
+++ b/framework/lib/components/select/select.tsx
@@ -158,7 +158,7 @@ export function Select<T extends Option, K extends boolean = false> ({
     value: is(Array, value) ? (value as T[]) : [],
   })
 
-  const customComponents = getComponents<T>()
+  const customComponents = getComponents<T>({ defaultControl: false })
 
   const prevOptions = useRef<OptionsOrGroups<T, GroupBase<T>> | undefined>(
     options


### PR DESCRIPTION
Reason for northlight docs search components bar getting stuck was becuase of newly added Control to select. Don't know why that caused a problem but it was not needed so made optional. Does not seem to cause any issues with normal select, only search bar

closed DEV-9227