### PR TITLE
fix(framework): added polyfill for window.matchMedia

### DIFF
--- a/framework/index.ts
+++ b/framework/index.ts
@@ -1,1 +1,3 @@
+import './matchMediaPolyfill'
+
 export * from './lib'

--- a/framework/matchMediaPolyfill.ts
+++ b/framework/matchMediaPolyfill.ts
@@ -1,0 +1,15 @@
+// window.matchMedia is used by chakra-react-select but is not defined in testing environment
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  window.matchMedia = (query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => true,
+  })
+}
+
+export {}

--- a/framework/test/unit/components/select/select-test.tsx
+++ b/framework/test/unit/components/select/select-test.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { assert } from 'chai'
+import { render, screen } from '@testing-library/react'
+import { MediatoolThemeProvider, Select } from '../../../../lib/components'
+import '../../../../matchMediaPolyfill'
+
+const { isOk } = assert
+
+describe('Select', () => {
+  it('Renders properly', () => {
+    render(
+      <MediatoolThemeProvider>
+        <Select data-testid="my-select" />
+      </MediatoolThemeProvider>
+    )
+
+    const input =
+      screen.getByTestId('my-select').children[0].children[2].children[0]
+        .children[1].children[0]
+
+    isOk(input)
+  })
+})


### PR DESCRIPTION
In chakra-react-select v.4.5.0 @chakra-ui/media-query was added as a dependency. This uses window.matchMedia api which is not defined in testing environment. This polyfills should effectively stub it in the library itself and fix the issues in the tests that use Northlight

closed DEV-9240