### PR TITLE
fix(framework): wrap getComponents in useMemo

### DIFF
--- a/framework/lib/components/search-bar/get-components.tsx
+++ b/framework/lib/components/search-bar/get-components.tsx
@@ -11,35 +11,7 @@ import { HStack } from '../stack'
 import { Icon } from '../icon'
 import { SearchBarOptionType } from './types'
 
-interface GetComponentsProps {
-  defaultControl?: boolean
-}
-
-export function getComponents<T extends SearchBarOptionType> ({
-  defaultControl = true,
-}: GetComponentsProps) {
-  const control = defaultControl
-    ? {}
-    : {
-      Control: ({
-        children,
-        ...props
-      }: ControlProps<T, boolean, GroupBase<T>>) =>
-        (props.selectProps.leftIcon ? (
-          <chakraComponents.Control { ...props }>
-            <HStack w="full" pl="2">
-              <Icon as={ props.selectProps.leftIcon } />
-              <HStack w="full" justify="space-between">
-                { children }
-              </HStack>
-            </HStack>
-          </chakraComponents.Control>
-        ) : (
-          <chakraComponents.Control { ...props }>
-            { children }
-          </chakraComponents.Control>
-        )),
-    }
+export function getComponents<T extends SearchBarOptionType> () {
   return {
     DropdownIndicator: (props: DropdownIndicatorProps<T>) =>
       (props.selectProps.icon ? (
@@ -67,6 +39,23 @@ export function getComponents<T extends SearchBarOptionType> ({
       ) : (
         <chakraComponents.MultiValueContainer { ...props } />
       )),
-    ...control,
+    Control: ({
+      children,
+      ...props
+    }: ControlProps<T, boolean, GroupBase<T>>) =>
+      (props.selectProps.leftIcon ? (
+        <chakraComponents.Control { ...props }>
+          <HStack w="full" pl="2">
+            <Icon as={ props.selectProps.leftIcon } />
+            <HStack w="full" justify="space-between">
+              { children }
+            </HStack>
+          </HStack>
+        </chakraComponents.Control>
+      ) : (
+        <chakraComponents.Control { ...props }>
+          { children }
+        </chakraComponents.Control>
+      )),
   }
 }

--- a/framework/lib/components/search-bar/search-bar.tsx
+++ b/framework/lib/components/search-bar/search-bar.tsx
@@ -49,7 +49,11 @@ export const SearchBar = forwardRef(
       isMulti,
       value: is(Array, value) ? value as T[] : [],
     })
-    const customComponents = getComponents<T>({ defaultControl: true })
+
+    const customComponents = useMemo(
+      () => getComponents<T>(),
+      []
+    )
 
     const simpleFilter = (query: string) => (
       filter(

--- a/framework/lib/components/select/select.tsx
+++ b/framework/lib/components/select/select.tsx
@@ -134,6 +134,7 @@ render(<CustomSelect />);
  * />
  * ?)
 */
+
 export function Select<T extends Option, K extends boolean = false> ({
   options,
   isMulti,
@@ -158,7 +159,10 @@ export function Select<T extends Option, K extends boolean = false> ({
     value: is(Array, value) ? (value as T[]) : [],
   })
 
-  const customComponents = getComponents<T>({ defaultControl: false })
+  const customComponents = useMemo(
+    () => getComponents<T>(),
+    []
+  )
 
   const prevOptions = useRef<OptionsOrGroups<T, GroupBase<T>> | undefined>(
     options


### PR DESCRIPTION
closed DEV-9245

The multi select dropdown would not close when clicked outside, The search bar also had problems with focus and could not type more than one letter a time.

Both problems were related to the addition of a custom Control under getComponents. I have no idea why that component specifically caused an issue, but when defined inside the react component it rerendered weirdly, causing problems, see:

://github.com/JedWatson/react-select/issues/4845#issuecomment-1665190832

This should be solved by wrapping in useMemo with empty deps so does not interfere with other rerenders