### PR TITLE
chore(framework): export tablecellprops interface

### DIFF
--- a/framework/lib/components/table/index.ts
+++ b/framework/lib/components/table/index.ts
@@ -8,5 +8,9 @@ export {
   TableCaption,
   TableContainer,
 } from '@chakra-ui/react'
+export type {
+  TableCellProps,
+} from '@chakra-ui/react'
+
 export * from './table'
 export * from './types'


### PR DESCRIPTION
This commit re-exports the TableCellProps interface from "@chakra-ui/react". This interface contains all the properties for table elements, such as "td", "th", etc.