### PR TITLE
fix(framework): support types for "as" component in Button

### DIFF
--- a/framework/lib/components/button/button.tsx
+++ b/framework/lib/components/button/button.tsx
@@ -47,7 +47,7 @@ import { ButtonProps } from './types'
  * ?)
  */
 export const Button = forwardRef(
-  ({ variant = 'default', children, ...rest }: ButtonProps, ref: any) => (
+  <As extends React.ElementType = typeof ChakraButton>({ variant = 'default', children, ...rest }: ButtonProps<As>, ref: any) => (
     <ChakraButton variant={ variant } ref={ ref } { ...rest }>
       { children }
     </ChakraButton>

--- a/framework/lib/components/button/types.ts
+++ b/framework/lib/components/button/types.ts
@@ -1,6 +1,12 @@
 import { ButtonProps as ChakraButtonProps } from '@chakra-ui/react'
+import { ComponentProps } from 'react'
 
 export type ButtonVariants = 'default' | 'danger' | 'success' | 'brand' | 'brandSubdued' | 'link' | 'ghost'
-export interface ButtonProps extends ChakraButtonProps {
+
+export type ButtonProps<As extends React.ElementType> = Omit<ChakraButtonProps, 'as'> & GenericAsProps<As> & {
   variant?: ButtonVariants
 }
+
+export type GenericAsProps<As extends React.ElementType> = (
+  { as?: As } & ComponentProps<As>
+)


### PR DESCRIPTION
This commit fixes the issue when specifying "as" property on the button component would not lead to the base component inferring props from component specified in "as".

This code would throw an error saying that "layoutId" is not a valid property:
  <HStack as={motion.div} layoutId="a" />

This commit fixes the issue, by parsing available assume component props and appending them to the base props (ButtonProps).