### PR TITLE
fix(northlight/components): fix datepicker trigger alignment

### DIFF
--- a/framework/lib/components/date-picker/date-picker/date-picker.tsx
+++ b/framework/lib/components/date-picker/date-picker/date-picker.tsx
@@ -108,7 +108,10 @@ export const DatePicker = (props: DatePickerProps) => {
                 />
               </Box>
             </StyledField>
-            <InputRightElement zIndex={ 0 }>
+            <InputRightElement
+              sx={ { height: '100%', paddingRight: '1' } }
+              zIndex={ 0 }
+            >
               <Trigger
                 { ...buttonProps }
                 isDisabled={ isDisabled }

--- a/framework/lib/components/date-picker/date-picker/date-range-picker.tsx
+++ b/framework/lib/components/date-picker/date-picker/date-range-picker.tsx
@@ -156,7 +156,7 @@ export const DateRangePicker = (props: DateRangePickerProps) => {
                 />
               </HStack>
             </StyledField>
-            <InputRightElement>
+            <InputRightElement sx={ { height: '100%', paddingRight: '1' } }>
               <Trigger
                 { ...buttonProps }
                 isDisabled={ isDisabled }


### PR DESCRIPTION
Fixed the daterange picker vertical-alignment

closes: DEV-9365

<img width="1055" alt="Screenshot 2023-10-12 at 16 41 15" src="https://github.com/mediatool/northlight/assets/5406237/6c5d4d68-7cd6-4591-ad01-344bc17e8577">

