### PR TITLE
fix(framework): changed placeholder color editabletext

### DIFF
--- a/framework/lib/components/editable-text/editable-text.tsx
+++ b/framework/lib/components/editable-text/editable-text.tsx
@@ -43,7 +43,7 @@ export const EditableText = ({
   ...rest
 }: EditableProps) => {
   const [ value, setValue ] = useState(inputValue)
-  const { input, preview } = useMultiStyleConfig('EditableText', { size })
+  const { input, preview } = useMultiStyleConfig('EditableText', { size, value })
 
   useEffect(() => {
     setValue(inputValue)

--- a/framework/lib/theme/components/editable-text/index.ts
+++ b/framework/lib/theme/components/editable-text/index.ts
@@ -1,4 +1,5 @@
 import { ComponentMultiStyleConfig } from '@chakra-ui/react'
+import { isEmpty, isNil } from 'ramda'
 
 export const EditableText: ComponentMultiStyleConfig = {
   parts: [ 'button', 'icon', 'controls', 'preview', 'input' ],
@@ -61,7 +62,7 @@ export const EditableText: ComponentMultiStyleConfig = {
       },
     }),
   },
-  baseStyle: {
+  baseStyle: ({ value }) => ({
     controls: {
       mr: 1,
     },
@@ -72,9 +73,10 @@ export const EditableText: ComponentMultiStyleConfig = {
       overflow: 'hidden',
       paddingTop: 0,
       paddingBottom: 0,
+      color: isNil(value) || isEmpty(value) ? 'text.subdued' : 'text.default',
     },
     input: {
       fontWeight: 'semibold',
     },
-  },
+  }),
 }


### PR DESCRIPTION
https://github.com/mediatool/northlight/assets/90923099/86715332-35e7-4a93-bbe1-cf185efdcac5

@unganemo it seems to me that the placeholder actually looked like the value instead of a placeholder. I changed the color which should clear up any confusion.
