### PR TITLE
fix(framework): step stack

### DIFF
--- a/framework/lib/components/step-stack/step-stack.tsx
+++ b/framework/lib/components/step-stack/step-stack.tsx
@@ -18,7 +18,7 @@ import { Box } from '../box'
   <br /><br />
   ## Simple step stack
   (?
-    <StepStack maxW="sm" spacing="4" rowHeight="10">
+    <StepStack maxW="sm" spacing="4" rowHeight="12">
       { Array.from({length: 5}, (_, i) => i).map((i) => <Input key={ i } />) }
     </StepStack>
   ?)
@@ -71,6 +71,7 @@ export const StepStack = ({
 }: StepStackProps) => {
   const rows = getChildrenWithProps(children, {})
   const parsedRowHeight = useToken('sizes', rowHeight)
+  const parcedSpacing = useToken('space', spacing)
 
   return (
     <Stack spacing={ spacing } position="relative" { ...rest }>
@@ -104,8 +105,8 @@ export const StepStack = ({
       <Divider
         orientation="vertical"
         left="3"
-        top={ `calc(${parsedRowHeight} / 2 + ${stepCircleMarginTopPx}px)` }
-        h={ `calc(100% - ${parsedRowHeight} - ${stepCircleMarginTopPx}px)` }
+        top={ `calc(${parsedRowHeight} / 2 + ${stepCircleMarginTopPx}px - ${parcedSpacing})` }
+        h={ `calc(100%  - ${parsedRowHeight} - ${stepCircleMarginTopPx}px + ${parcedSpacing})` }
         position="absolute"
       />
     </Stack>

--- a/framework/lib/components/step-stack/types.ts
+++ b/framework/lib/components/step-stack/types.ts
@@ -4,6 +4,7 @@ import { StackProps } from '@chakra-ui/react'
 export interface StepStackProps extends StackProps {
   children: ReactNode | ReactNode[]
   rowHeight?: string
+  spacing?: string
   /** The vertical alignment of the circles.
    * Accepts any values that can be used with the alignItems CSS property.
    * Defaults to "center".


### PR DESCRIPTION
when calculating the height and top for the step stack divider the spacing wasn't considered, hence the divider was positioned slightly off. I've added the spacing to both top and height.