### PR TITLE
fix(framework): tooltip not working on multiple components

### DIFF
--- a/framework/lib/components/checkbox/checkbox-field.tsx
+++ b/framework/lib/components/checkbox/checkbox-field.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { identity } from 'ramda'
 import { CheckboxFieldProps } from './types'
 import { Field } from '../form'
@@ -27,7 +27,7 @@ import { Flex } from '../flex'
  *
  */
 
-export const CheckboxField = ({
+export const CheckboxField = forwardRef<HTMLDivElement, CheckboxFieldProps>(({
   name,
   label,
   variant,
@@ -38,7 +38,7 @@ export const CheckboxField = ({
   labelPlacement = 'left',
   labelSize = 'md',
   ...rest
-}: CheckboxFieldProps) => (
+}, ref) => (
   <Box
     w={ label ? 'full' : 'fit-content' }
     display="inline-flex"
@@ -49,6 +49,7 @@ export const CheckboxField = ({
       isRequired={ isRequired }
       direction={ direction }
       validate={ validate }
+      ref={ ref }
     >
       { ({ onChange, value }) => (
         <Flex
@@ -71,4 +72,4 @@ export const CheckboxField = ({
       ) }
     </Field>
   </Box>
-)
+))

--- a/framework/lib/components/date-picker/date-picker-field/date-picker-field.tsx
+++ b/framework/lib/components/date-picker/date-picker-field/date-picker-field.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { DateValue, parseDate } from '@internationalized/date'
 import { identity } from 'ramda'
 import { DatePickerFieldProps } from '../types'
@@ -29,7 +29,7 @@ import { InputGroupWrapper } from '../../../internal-components/input-group-wrap
  * yyyy-mm-dd on the onSubmit callback on <Form>
  *
  */
-export const DatePickerField = ({
+export const DatePickerField = forwardRef<HTMLDivElement, DatePickerFieldProps>(({
   name,
   minValue,
   maxValue,
@@ -42,7 +42,7 @@ export const DatePickerField = ({
   inputLeftElement,
   inputRightElement,
   ...rest
-}: DatePickerFieldProps) => {
+}, ref) => {
   const { setValue, setError, trigger } = useFormContext()
 
   const handleChange = (date: DateValue) => {
@@ -70,6 +70,7 @@ export const DatePickerField = ({
       direction={ direction }
       isRequired={ isRequired }
       validate={ validate }
+      ref={ ref }
     >
       { ({ value, onChange }, { formState: { errors } }) => (
         <InputGroupWrapper
@@ -93,4 +94,4 @@ export const DatePickerField = ({
     </Field>
 
   )
-}
+})

--- a/framework/lib/components/date-picker/date-picker-field/date-range-picker-field.tsx
+++ b/framework/lib/components/date-picker/date-picker-field/date-range-picker-field.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { identity } from 'ramda'
 import { DateRangePickerFieldProps, FormBody } from '../types'
 import { Field } from '../../form'
@@ -12,7 +12,7 @@ import { useFormContext } from '../../../hooks'
  * @see {@link https://northlight.dev/reference/date-range-picker-field}
  *
  */
-export const DateRangePickerField = ({
+export const DateRangePickerField = forwardRef<HTMLDivElement, DateRangePickerFieldProps>(({
   name,
   minValue,
   maxValue,
@@ -24,7 +24,7 @@ export const DateRangePickerField = ({
   onChange: onChangeCallback = identity,
   isClearable = true,
   ...rest
-}: DateRangePickerFieldProps) => {
+}, ref) => {
   const { setValue, setError, trigger } = useFormContext<FormBody>()
 
   const handleChange = (dateRange: { startDate: string, endDate: string }) => {
@@ -55,6 +55,7 @@ export const DateRangePickerField = ({
       direction={ direction }
       isRequired={ isRequired }
       validate={ validate }
+      ref={ ref }
     >
       { ({ value, onChange }, { formState: { errors } }) => (
         <DateRangePicker
@@ -73,4 +74,4 @@ export const DateRangePickerField = ({
       ) }
     </Field>
   )
-}
+})

--- a/framework/lib/components/drag-and-drop/drag-item.tsx
+++ b/framework/lib/components/drag-and-drop/drag-item.tsx
@@ -18,13 +18,13 @@ import { DragItemProps } from './types'
  * ?)
  *
  */
-export const DragItem = forwardRef(({
+export const DragItem = forwardRef<HTMLSpanElement, DragItemProps>(({
   size = 'md',
   isDragging,
   itemLabel = 'Drag Me',
   bgColor,
   ...rest
-}: DragItemProps, ref) => (
+}, ref) => (
   <Tag
     ref={ ref }
     cursor={ isDragging ? 'grabbing' : 'grab' }

--- a/framework/lib/components/flip-button/flip-button-group-field.tsx
+++ b/framework/lib/components/flip-button/flip-button-group-field.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { identity } from 'ramda'
 import { Field } from '../form'
 import { FlipButtonGroup } from './flip-button-group'
@@ -23,7 +23,7 @@ import { FlipButtonGroupFieldProps } from './types'
  * ?)
  *
  */
-export const FlipButtonGroupField = ({
+export const FlipButtonGroupField = forwardRef<HTMLDivElement, FlipButtonGroupFieldProps>(({
   name,
   label,
   children,
@@ -33,13 +33,14 @@ export const FlipButtonGroupField = ({
   onChange: onChangeCallback = identity,
   validate,
   ...rest
-}: FlipButtonGroupFieldProps) => (
+}, ref) => (
   <Field
     name={ name }
     label={ label }
     direction={ direction }
     isRequired={ isRequired }
     validate={ validate }
+    ref={ ref }
   >
     { ({ onChange, value }) => (
       <FlipButtonGroup
@@ -54,4 +55,4 @@ export const FlipButtonGroupField = ({
       </FlipButtonGroup>
     ) }
   </Field>
-)
+))

--- a/framework/lib/components/form-control/form-label.tsx
+++ b/framework/lib/components/form-control/form-label.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { FormLabelProps } from './types'
 import { Label } from '../typography'
 
@@ -8,10 +8,10 @@ import { Label } from '../typography'
  * @see {@link https://northlight.dev/reference/form-label}
  *
  */
-export const FormLabel = ({
+export const FormLabel = forwardRef<HTMLLabelElement, FormLabelProps >(({
   children: label,
   ...rest
-}: FormLabelProps) => (
+}, ref) => (
   <Label
     size="sm"
     sx={ {
@@ -22,7 +22,8 @@ export const FormLabel = ({
     } }
     requiredIndicator={ undefined }
     { ...rest }
+    ref={ ref }
   >
     { label }
   </Label>
-)
+))

--- a/framework/lib/components/form/field.tsx
+++ b/framework/lib/components/form/field.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { Controller, FieldPath, FieldValues } from 'react-hook-form'
 import { FormControl, FormErrorMessage, FormLabel } from '../form-control'
 import { Stack } from '../stack'
@@ -97,20 +97,20 @@ import { getFieldError } from '../../utils'
  * `<Field<MyFormBody> name="username">...</Field>`
  */
 
-export function Field<
+const BaseField = <
   FormValues extends FieldValues = FieldValues,
   FieldName extends FieldPath<FormValues> = FieldPath<FormValues>
 > ({
-  name,
-  label,
-  children,
-  direction = 'column',
-  isRequired = false,
-  noLabelConnection = false,
-  validate,
-  control: passedControl,
-  ...rest
-}: FieldProps<FormValues, FieldName>) {
+    name,
+    label,
+    children,
+    direction = 'column',
+    isRequired = false,
+    noLabelConnection = false,
+    validate,
+    control: passedControl,
+    ...rest
+  }: FieldProps<FormValues, FieldName>, ref: React.Ref<HTMLDivElement>) => {
   const methods = useFormContext<FormValues>()
   const { formState: { errors } } = methods
   const control = passedControl ?? methods.control
@@ -118,7 +118,7 @@ export function Field<
   const fieldError = getFieldError<FormValues>(name, errors)
 
   return (
-    <FormControl isInvalid={ !!fieldError } isRequired={ isRequired }>
+    <FormControl isInvalid={ !!fieldError } isRequired={ isRequired } ref={ ref }>
       <Stack
         spacing="auto"
         direction={ direction }
@@ -143,3 +143,5 @@ export function Field<
     </FormControl>
   )
 }
+
+export const Field = forwardRef(BaseField)

--- a/framework/lib/components/number-input/number-input-field.tsx
+++ b/framework/lib/components/number-input/number-input-field.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { forwardRef, useState } from 'react'
 import { identity, isNil } from 'ramda'
 import { NumberInputFieldProps } from './types'
 import { Field } from '../form'
@@ -13,7 +13,7 @@ import { InputGroupWrapper } from '../../internal-components/input-group-wrapper
  * @see {@link https://northlight.dev/reference/number-input-field}
  *
  */
-export const NumberInputField = ({
+export const NumberInputField = forwardRef<HTMLDivElement, NumberInputFieldProps>(({
   name,
   label,
   direction,
@@ -24,7 +24,7 @@ export const NumberInputField = ({
   inputLeftElement,
   inputRightElement,
   ...rest
-}: NumberInputFieldProps) => {
+}, ref) => {
   const formatNumber = (value: number, factor: number) => (
     onlyAcceptPercentage
       ? advancedParseFloat(value * factor)
@@ -38,6 +38,7 @@ export const NumberInputField = ({
       direction={ direction }
       isRequired={ isRequired }
       validate={ validate }
+      ref={ ref }
     >
       { ({ onChange, value }) => {
         const initialValue = isNil(value) || Number.isNaN(parseFloat(value))
@@ -70,4 +71,4 @@ export const NumberInputField = ({
       } }
     </Field>
   )
-}
+})

--- a/framework/lib/components/radio/radio-group-field.tsx
+++ b/framework/lib/components/radio/radio-group-field.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { identity } from 'ramda'
 import { RadioFieldGroupProps } from './types'
 import { Field } from '../form'
@@ -13,7 +13,7 @@ import { Box } from '../box'
  * @see {@link https://northlight.dev/reference/radio-group-field}
  *
  */
-export const RadioGroupField = ({
+export const RadioGroupField = forwardRef<HTMLDivElement, RadioFieldGroupProps>(({
   name,
   label,
   children,
@@ -22,7 +22,7 @@ export const RadioGroupField = ({
   validate,
   onChange: onChangeCallback = identity,
   ...rest
-}: RadioFieldGroupProps) => (
+}, ref) => (
   <Box w={ label ? 'full' : 'fit-content' }>
     <Field
       name={ name }
@@ -30,6 +30,7 @@ export const RadioGroupField = ({
       direction={ direction }
       isRequired={ isRequired }
       validate={ validate }
+      ref={ ref }
     >
       { ({ onChange, value }) => (
         <RadioGroup
@@ -45,4 +46,4 @@ export const RadioGroupField = ({
       ) }
     </Field>
   </Box>
-)
+))

--- a/framework/lib/components/search-bar/search-bar-field.tsx
+++ b/framework/lib/components/search-bar/search-bar-field.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { FieldValues } from 'react-hook-form'
 import { XCloseSolid } from '@northlight/icons'
 import { identity, isEmpty } from 'ramda'
@@ -10,7 +10,7 @@ import { IconButton } from '../icon-button'
 import { Icon } from '../icon'
 import { InputGroupWrapper } from '../../internal-components/input-group-wrapper/input-group-wrapper'
 
-export const SearchBarField = <T extends SearchBarOptionType, K extends boolean = false> ({
+const BaseSearchBarField = <T extends SearchBarOptionType, K extends boolean = false> ({
   name,
   label,
   direction = 'column',
@@ -22,7 +22,7 @@ export const SearchBarField = <T extends SearchBarOptionType, K extends boolean 
   inputLeftElement,
   inputRightElement,
   ...rest
-}: SearchBarFieldProps<T, K>) => (
+}: SearchBarFieldProps<T, K>, ref: React.Ref<HTMLDivElement>) => (
   <Field
     name={ name }
     label={ label }
@@ -30,6 +30,7 @@ export const SearchBarField = <T extends SearchBarOptionType, K extends boolean 
     isRequired={ isRequired }
     noLabelConnection={ true }
     validate={ validate }
+    ref={ ref }
   >
     { ({ value, onChange }) => (
       <HStack w="full">
@@ -65,3 +66,5 @@ export const SearchBarField = <T extends SearchBarOptionType, K extends boolean 
     ) }
   </Field>
   )
+
+export const SearchBarField = forwardRef(BaseSearchBarField)

--- a/framework/lib/components/select/select-field.tsx
+++ b/framework/lib/components/select/select-field.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { XCloseSolid } from '@northlight/icons'
 import { identity } from 'ramda'
 import { Option, SelectFieldProps } from './types'
@@ -9,7 +9,7 @@ import { IconButton } from '../icon-button'
 import { Icon } from '../icon'
 import { InputGroupWrapper } from '../../internal-components/input-group-wrapper/input-group-wrapper'
 
-export function SelectField<T extends Option, K extends boolean = false> ({
+const BaseSelectField = <T extends Option, K extends boolean = false> ({
   name,
   label,
   options,
@@ -22,54 +22,55 @@ export function SelectField<T extends Option, K extends boolean = false> ({
   inputLeftElement,
   inputRightElement,
   ...rest
-}: SelectFieldProps<T, K>) {
-  return (
-    <Field
-      name={ name }
-      label={ label }
-      direction={ direction }
-      isRequired={ isRequired }
-      noLabelConnection={ true }
-      validate={ validate }
-    >
-      { ({ value, onChange }) => (
-        <HStack w="full">
-          <InputGroupWrapper
-            inputLeftElement={ inputLeftElement }
-            inputRightElement={ inputRightElement }
-          >
-            <Select<T, K>
-              name={ name }
-              options={ options }
-              isMulti={ isMulti }
-              onChange={ (values, event) => {
-                onChange(
-                  isMulti
-                    ? (values as T[]).map((item: any) => item.value)
-                    : (values as T).value
-                )
-                onChangeCallback(values as K extends true ? T[] : T, event)
-              } }
-              value={
+}: SelectFieldProps<T, K>, ref: React.Ref<HTMLDivElement>) => (
+  <Field
+    name={ name }
+    label={ label }
+    direction={ direction }
+    isRequired={ isRequired }
+    noLabelConnection={ true }
+    validate={ validate }
+    ref={ ref }
+  >
+    { ({ value, onChange }) => (
+      <HStack w="full">
+        <InputGroupWrapper
+          inputLeftElement={ inputLeftElement }
+          inputRightElement={ inputRightElement }
+        >
+          <Select<T, K>
+            name={ name }
+            options={ options }
+            isMulti={ isMulti }
+            onChange={ (values, event) => {
+              onChange(
+                isMulti
+                  ? (values as T[]).map((item: any) => item.value)
+                  : (values as T).value
+              )
+              onChangeCallback(values as K extends true ? T[] : T, event)
+            } }
+            value={
               value
                 ? options?.flatMap((inner : any) => (inner.options ? inner.options : inner))
                   .filter((option: any) => value.includes(option.value)) as any
                 : null
             }
-              { ...rest }
-            />
-          </InputGroupWrapper>
-          <IconButton
-            aria-label={ `${name}-close-button` }
-            variant="danger"
-            size="sm"
-            fontSize="xs"
-            hidden={ value === undefined || !isClearable }
-            onClick={ () => { onChange(undefined) } }
-            icon={ <Icon as={ XCloseSolid } /> }
+            { ...rest }
           />
-        </HStack>
-      ) }
-    </Field>
+        </InputGroupWrapper>
+        <IconButton
+          aria-label={ `${name}-close-button` }
+          variant="danger"
+          size="sm"
+          fontSize="xs"
+          hidden={ value === undefined || !isClearable }
+          onClick={ () => { onChange(undefined) } }
+          icon={ <Icon as={ XCloseSolid } /> }
+        />
+      </HStack>
+    ) }
+  </Field>
   )
-}
+
+export const SelectField = forwardRef(BaseSelectField)

--- a/framework/lib/components/switch/switch-field.tsx
+++ b/framework/lib/components/switch/switch-field.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { identity } from 'ramda'
 import { SwitchFieldProps } from './types'
 import { Field } from '../form'
@@ -29,8 +29,7 @@ import { Label } from '../typography'
  * ?)
  *
  */
-
-export const SwitchField = ({
+export const SwitchField = forwardRef<HTMLDivElement, SwitchFieldProps>(({
   name,
   label,
   isRequired,
@@ -40,17 +39,15 @@ export const SwitchField = ({
   labelPlacement = 'right',
   labelSize = 'md',
   ...rest
-}: SwitchFieldProps) => (
-  <Box
-    w={ label ? 'full' : 'fit-content' }
-    display="inline-flex"
-  >
+}, ref) => (
+  <Box w={ label ? 'full' : 'fit-content' } display="inline-flex">
     <Field
       name={ name }
       label=""
       isRequired={ isRequired }
       direction={ direction }
       validate={ validate }
+      ref={ ref }
     >
       { ({ onChange, value }) => (
         <Flex
@@ -74,4 +71,4 @@ export const SwitchField = ({
       ) }
     </Field>
   </Box>
-)
+))

--- a/framework/lib/components/tag/tag.tsx
+++ b/framework/lib/components/tag/tag.tsx
@@ -20,13 +20,13 @@ import { TagProps } from './types'
  * ?)
  *
 */
-export const Tag = forwardRef(({
+export const Tag = forwardRef<HTMLSpanElement, TagProps>(({
   children,
   variant = 'solid',
   bgColor,
   colorScheme,
   ...rest
-}: TagProps, ref: any) => (
+}, ref) => (
   <ChakraTag
     bgColor={ bgColor }
     colorScheme={ colorScheme }

--- a/framework/lib/components/text-field/formatted-number-input-field.tsx
+++ b/framework/lib/components/text-field/formatted-number-input-field.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { identity } from 'ramda'
 import { FormattedNumberInputFieldProps } from './types'
 import { Field } from '../form'
@@ -21,7 +21,8 @@ import { FormattedNumberInput } from './formatted-number-input'
  * ?)
  *
  */
-export const FormattedNumberInputField = ({
+export const FormattedNumberInputField =
+forwardRef<HTMLDivElement, FormattedNumberInputFieldProps>(({
   name,
   label,
   isRequired,
@@ -29,13 +30,14 @@ export const FormattedNumberInputField = ({
   onChange: onChangeCallback = identity,
   direction = 'row',
   ...rest
-}: FormattedNumberInputFieldProps) => (
+}, ref) => (
   <Field
     name={ name }
     label={ label }
     isRequired={ isRequired }
     direction={ direction }
     validate={ validate }
+    ref={ ref }
   >
     { ({ onChange, value }) => (
       <FormattedNumberInput
@@ -49,4 +51,4 @@ export const FormattedNumberInputField = ({
       />
     ) }
   </Field>
-)
+))

--- a/framework/lib/components/text-field/text-field.tsx
+++ b/framework/lib/components/text-field/text-field.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { identity, isNil } from 'ramda'
 import { TextFieldProps } from './types'
 import { Input } from '../input'
@@ -15,7 +15,7 @@ import { InputGroupWrapper } from '../../internal-components/input-group-wrapper
  *
  *
  */
-export const TextField = ({
+export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(({
   name,
   label,
   as: As = Input,
@@ -26,7 +26,7 @@ export const TextField = ({
   inputLeftElement,
   inputRightElement,
   ...rest
-}: TextFieldProps) => (
+}, ref) => (
   <Field
     name={ name }
     label={ label }
@@ -37,6 +37,7 @@ export const TextField = ({
         : validate
     }
     direction={ direction }
+    ref={ ref }
   >
     { ({ onChange, value }) => (
       <InputGroupWrapper
@@ -57,4 +58,4 @@ export const TextField = ({
       </InputGroupWrapper>
     ) }
   </Field>
-)
+))

--- a/framework/lib/components/textarea/textarea-field.tsx
+++ b/framework/lib/components/textarea/textarea-field.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { identity } from 'ramda'
 import { TextareaFieldProps } from './types'
 import { Field } from '../form'
 import { Textarea } from './textarea'
 
-export const TextareaField = ({
+export const TextareaField = forwardRef<HTMLDivElement, TextareaFieldProps>(({
   name,
   label,
   isRequired,
@@ -12,13 +12,14 @@ export const TextareaField = ({
   direction,
   onChange: onChangeCallback = identity,
   ...rest
-}: TextareaFieldProps) => (
+}, ref) => (
   <Field
     name={ name }
     label={ label }
     isRequired={ isRequired }
     validate={ validate }
     direction={ direction }
+    ref={ ref }
   >
     { ({ onChange, value }) => (
       <Textarea
@@ -30,4 +31,4 @@ export const TextareaField = ({
       />
     ) }
   </Field>
-)
+))

--- a/framework/lib/components/typography/labels/label.tsx
+++ b/framework/lib/components/typography/labels/label.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { FormLabel, VisuallyHidden, useStyleConfig } from '@chakra-ui/react'
 import { LabelProps } from './types'
 
@@ -18,21 +18,22 @@ import { LabelProps } from './types'
  * under the props tab to right should be passed down via **sx**_)
  *
  */
-export const Label = ({
+export const Label = forwardRef<HTMLLabelElement, LabelProps>(({
   children,
   size = 'sm',
   sx = {},
   ...rest
-}: LabelProps) => {
+}, ref) => {
   const styles = useStyleConfig('Label', { sx, size })
 
   return (
     <FormLabel
       sx={ styles }
       requiredIndicator={ <VisuallyHidden /> }
+      ref={ ref }
       { ...rest }
     >
       { children }
     </FormLabel>
   )
-}
+})


### PR DESCRIPTION
The tooltip was weirdly placed on all field components, as well as formlabel and label. This was due to a ref not being passed down, and so the tooltip did not know where to render and rendered in upper corner.

closed: DEV-9728