### PR TITLE
fix(framework): Select dropdown direction if cant fit in modal

### DIFF
--- a/framework/lib/components/select/constants.ts
+++ b/framework/lib/components/select/constants.ts
@@ -1,0 +1,4 @@
+export const DROPDOWN_MAX_HEIGHT = 300
+export const DROPDOWN_MIN_HEIGHT = 55
+export const DROPDOWN_OPTION_HEIGHT = 37
+export const DROPDOWN_PADDING = 30

--- a/framework/lib/components/select/select.tsx
+++ b/framework/lib/components/select/select.tsx
@@ -6,12 +6,14 @@ import {
   SelectInstance,
 } from 'chakra-react-select'
 import { Box } from '@chakra-ui/react'
-import { equals, identity, is } from 'ramda'
+import { equals, identity, is, length } from 'ramda'
 import { Option, SelectProps } from './types'
 import { customSelectStyles } from '../../theme/components/select/custom-select'
 import { useSelectCallbacks } from '../../hooks'
 import { getComponents } from '../search-bar/get-components'
 import { getMatchingValue } from './get-matching-value'
+import { useAdaptiveMenuPlacement } from './use-adaptive-menu-placement'
+import { DROPDOWN_MAX_HEIGHT, DROPDOWN_MIN_HEIGHT, DROPDOWN_OPTION_HEIGHT, DROPDOWN_PADDING } from './constants'
 
 /**
  * Select component that provides a customizable and accessible select input.
@@ -149,6 +151,8 @@ export const Select = forwardRef(<T extends Option, K extends boolean = false>({
   customTag = null,
   value,
   icon,
+  containerRef,
+  dropdownMinHeightPx = DROPDOWN_MIN_HEIGHT,
   ...rest
 }: SelectProps<T, K>,
   ref: Ref<SelectInstance<T, K, GroupBase<T>>>
@@ -176,8 +180,21 @@ export const Select = forwardRef(<T extends Option, K extends boolean = false>({
     return prevOptions.current
   }, [ options ])
 
+  const dropdownHeightPx = Math.max(
+    Math.min(
+      length(options || []) * DROPDOWN_OPTION_HEIGHT + DROPDOWN_PADDING,
+      DROPDOWN_MAX_HEIGHT
+    ),
+    dropdownMinHeightPx
+  )
+
+  const { selectContainerRef, menuPlacement } = useAdaptiveMenuPlacement({
+    dropdownHeightPx,
+    containerRef,
+  })
+
   return (
-    <Box w="full" data-testid={ testId }>
+    <Box w="full" data-testid={ testId } data-role="select-container" ref={ selectContainerRef }>
       <ChakraReactSelect
         isMulti={ isMulti }
         options={ renderedOptions }
@@ -194,6 +211,7 @@ export const Select = forwardRef(<T extends Option, K extends boolean = false>({
         customOption={ customOption }
         customTag={ customTag }
         icon={ icon }
+        menuPlacement={ menuPlacement }
         components={ customComponents }
         ref={ ref }
         { ...rest }

--- a/framework/lib/components/select/types.ts
+++ b/framework/lib/components/select/types.ts
@@ -1,3 +1,4 @@
+import { ComponentType, Ref, RefObject } from 'react'
 import {
   ActionMeta,
   Props as ChakraReactSelectProps,
@@ -8,7 +9,6 @@ import {
   SingleValue,
 } from 'chakra-react-select'
 import { StackDirection } from '@chakra-ui/react'
-import { ComponentType, Ref } from 'react'
 import { RegisterOptions } from 'react-hook-form'
 import { InputFieldProps } from '../../types'
 
@@ -45,6 +45,15 @@ export interface SelectProps<T, K extends boolean>
   customOption?: ((option: T) => JSX.Element) | null
   isMulti?: K
   ref?: Ref<SelectInstance<T, K, GroupBase<T>>>
+  /** Points to the container that the select refers to when deciding where to fit menu.
+   * E.g if you render the select in a modal you may want to sent
+   *  containerRef equal to a ref pointing to that modal,
+   *  because in that case the select dropdown change placement to try and stay within the modal */
+  containerRef?: UseAdaptiveMenuPlacementProps['containerRef']
+  /** The min height that will be reserveed for the select dropdown, used to determine wheter to put
+   * dropdown on top of or bottom of select
+  */
+  dropdownMinHeightPx?: number
 }
 
 export type SelectFieldProps<T, K extends boolean = false> = SelectProps<T, K> &
@@ -54,4 +63,9 @@ Omit<InputFieldProps, 'isMulti'> & {
   label: string
   validate?: RegisterOptions
   isRequired?: boolean
+}
+
+export interface UseAdaptiveMenuPlacementProps {
+  dropdownHeightPx: number
+  containerRef?: RefObject<HTMLDivElement>
 }

--- a/framework/lib/components/select/use-adaptive-menu-placement.ts
+++ b/framework/lib/components/select/use-adaptive-menu-placement.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef, useState } from 'react'
+import { isNil } from 'ramda'
+import { UseAdaptiveMenuPlacementProps } from './types'
+
+export const useAdaptiveMenuPlacement = ({
+  dropdownHeightPx,
+  containerRef,
+}: UseAdaptiveMenuPlacementProps) => {
+  const [ menuPlacement, setMenuPlacement ] = useState<'bottom' | 'top'>('bottom')
+  const selectContainerRef = useRef<HTMLDivElement>(null)
+
+  const adjustMenuPlacement = () => {
+    if (isNil(selectContainerRef.current)) return
+    let node = selectContainerRef.current.parentNode as HTMLDivElement
+    while (node.parentNode) {
+      const { overflowY, maxHeight, height } = getComputedStyle(node)
+      if (overflowY !== 'visible' || maxHeight || height) break
+      node = node.parentNode as HTMLDivElement
+    }
+
+    const selectRect = selectContainerRef.current.getBoundingClientRect()
+    const containerRect =
+      containerRef && containerRef.current
+        ? containerRef.current.getBoundingClientRect()
+        : node.getBoundingClientRect()
+    const pxToContainerBottom = Math.abs(
+      selectRect.bottom - containerRect.bottom
+    )
+    const pxToContainerTop = Math.abs(selectRect.top - containerRect.top)
+    const pxToWindowBottom = Math.abs(selectRect.bottom - window.innerHeight)
+
+    const shouldBeAtTop =
+      (dropdownHeightPx > pxToContainerBottom && pxToContainerTop > pxToContainerBottom) ||
+      (dropdownHeightPx > pxToWindowBottom && selectRect.top > pxToWindowBottom)
+
+    setMenuPlacement(shouldBeAtTop ? 'top' : 'bottom')
+  }
+
+  useEffect(() => {
+    adjustMenuPlacement()
+    window.addEventListener('resize', adjustMenuPlacement)
+    window.addEventListener('scroll', adjustMenuPlacement)
+    return () => {
+      window.removeEventListener('resize', adjustMenuPlacement)
+      window.addEventListener('scroll', adjustMenuPlacement)
+    }
+  }, [])
+
+  return { selectContainerRef, menuPlacement }
+}


### PR DESCRIPTION
This will make it so the select dropdown will be displayed on top of the select input in case there is not enough space at the bottom. This applies for all container, including modal.

closed: DEV-9724


https://github.com/mediatool/northlight/assets/90923099/20539948-64c0-469e-ba2d-a56263b305f0


