### PR TITLE
fix(framework): change chakra ui spinner to northlight spinner

### DIFF
--- a/framework/lib/components/button/button.tsx
+++ b/framework/lib/components/button/button.tsx
@@ -1,6 +1,14 @@
 import React, { forwardRef } from 'react'
 import { Button as ChakraButton } from '@chakra-ui/react'
+import { Spinner } from '../spinner'
 import { ButtonProps } from './types'
+
+const SpinnerSizeMap = {
+  xs: 'xs',
+  sm: 'sm',
+  md: 'sm',
+  lg: 'md',
+}
 
 /**
  * @see {@link https://northlight.dev/reference/button}
@@ -47,8 +55,21 @@ import { ButtonProps } from './types'
  * ?)
  */
 export const Button = forwardRef(
-  <As extends React.ElementType = typeof ChakraButton>({ variant = 'default', children, ...rest }: ButtonProps<As>, ref: any) => (
-    <ChakraButton variant={ variant } ref={ ref } { ...rest }>
+  <As extends React.ElementType = typeof ChakraButton>(
+    { variant = 'default', children, size = 'md', ...rest }: ButtonProps<As>,
+    ref: any
+  ) => (
+    <ChakraButton
+      variant={ variant }
+      ref={ ref }
+      size={ size }
+      spinner={ (
+        <Spinner
+          size={ SpinnerSizeMap[size] }
+        />
+        ) }
+      { ...rest }
+    >
       { children }
     </ChakraButton>
   )

--- a/framework/lib/components/button/types.ts
+++ b/framework/lib/components/button/types.ts
@@ -3,8 +3,9 @@ import { ComponentProps } from 'react'
 
 export type ButtonVariants = 'default' | 'danger' | 'success' | 'brand' | 'brandSubdued' | 'link' | 'ghost'
 
-export type ButtonProps<As extends React.ElementType> = Omit<ChakraButtonProps, 'as'> & GenericAsProps<As> & {
+export type ButtonProps<As extends React.ElementType> = Omit<ChakraButtonProps, 'as' | 'size'> & Omit<GenericAsProps<As>, 'size'> & {
   variant?: ButtonVariants
+  size?: 'xs' | 'sm' | 'md' | 'lg'
 }
 
 export type GenericAsProps<As extends React.ElementType> = (


### PR DESCRIPTION


https://github.com/mediatool/northlight/assets/90923099/fdbfabc8-83ab-4575-a893-4894ab96b4c8

The spinner that was used for the loading state of the button was actually the default spinner provided by Chakra UI. By chaning the default spinner for our own spinner this fixed the issue

closed: DEV-9732