### PR TITLE
fix(framework): turn leftIcon into leftComponent

### DIFF
--- a/framework/lib/components/search-bar/get-components.tsx
+++ b/framework/lib/components/search-bar/get-components.tsx
@@ -43,10 +43,10 @@ export function getComponents<T extends SearchBarOptionType> () {
       children,
       ...props
     }: ControlProps<T, boolean, GroupBase<T>>) =>
-      (props.selectProps.leftIcon ? (
+      (props.selectProps.leftComponent ? (
         <chakraComponents.Control { ...props }>
           <HStack w="full" pl="2">
-            <Icon as={ props.selectProps.leftIcon } />
+            { props.selectProps.leftComponent }
             <HStack w="full" justify="space-between">
               { children }
             </HStack>

--- a/framework/lib/components/select/types.ts
+++ b/framework/lib/components/select/types.ts
@@ -40,8 +40,8 @@ export interface SelectProps<T, K extends boolean>
   | undefined
   /** Custom icon that will be put to the faremost right of the component */
   icon?: ComponentType<any>
-  /** Custom icon that will be put to the faremost left of the component */
-  leftIcon?: ComponentType<any>
+  /** Custom components that will be put to the faremost left of the select input box */
+  leftComponent?: React.ReactNode
   customOption?: ((option: T) => JSX.Element) | null
   isMulti?: K
   ref?: Ref<SelectInstance<T, K, GroupBase<T>>>

--- a/framework/lib/general.d.ts
+++ b/framework/lib/general.d.ts
@@ -15,7 +15,7 @@ declare module 'react-select/dist/declarations/src/Select' {
     customOption?: CustomElementType<Option>
     customTag?: CustomElementType<Option>
     icon?: ComponentType<any>
-    leftIcon?: ComponentType<any>
+    leftComponent?: React.ReactNode
   }
 }
 


### PR DESCRIPTION
This will generalize the existing leftIcon prop into being able to pass any React node to the left of the select input box

![Image 2023-10-31 at 17 28](https://github.com/mediatool/northlight/assets/90923099/f9032e0e-e1a6-41da-80fd-af0ad478bfe4)


closed: DEV-9895