### PR TITLE
fix(framework): improve date range picker UI/UX

### DIFF
--- a/framework/lib/components/date-picker/components/calendar/date-select/month-select.tsx
+++ b/framework/lib/components/date-picker/components/calendar/date-select/month-select.tsx
@@ -10,14 +10,12 @@ export const MonthSelect = ({
   const { dateSelect } = useMultiStyleConfig('Calendar')
   const start = state.visibleRange.start.add({ months: offset }).month - 1
   const [ selectedIndex, setSelectedIndex ] = useState(start)
-  const [ isEditing, setIsEditing ] = useState(false)
 
   const moveStartDateBy = (inp: any) => state.visibleRange.start.add(inp)
 
   const onChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const index = Number(e.target.value)
     setSelectedIndex(index)
-    setIsEditing(false)
     const diff = index - start
     state.setFocusedDate(moveStartDateBy({ months: diff }))
   }
@@ -28,41 +26,26 @@ export const MonthSelect = ({
     )
   }, [ state.visibleRange ])
 
-  const handleKeyDown = (e: any) => {
-    switch (e.key) {
-      case 'ArrowDown':
-      case 'ArrowUp':
-      case ' ':
-        setIsEditing((prev) => !prev)
-        break
-      default:
-        break
-    }
-  }
-
   return (
     <Select
       id="month"
       aria-label="Select Month"
       onChange={ onChange }
-      onClick={ () => setIsEditing((prev) => !prev) }
-      onKeyDown={ handleKeyDown }
       value={ selectedIndex }
       iconSize="0px"
       size="sm"
       variant="unstyled"
       sx={ dateSelect }
       w="max-content"
+      textAlign="center"
     >
-      { isEditing ? (
+      {
         months.map((month, i) => (
           <option key={ month } value={ i }>
             { month }
           </option>
         ))
-      ) : (
-        <option value={ selectedIndex }>{ months[selectedIndex] }</option>
-      ) }
+}
     </Select>
   )
 }

--- a/framework/lib/components/date-picker/components/calendar/quick-navigation/adjust-range.tsx
+++ b/framework/lib/components/date-picker/components/calendar/quick-navigation/adjust-range.tsx
@@ -5,6 +5,7 @@ import {
   ChevronDownSolid,
   ChevronUpSolid,
 } from '@northlight/icons'
+import { equals } from 'ramda'
 import { CalendarDate } from '@internationalized/date'
 import { Lead, P } from '../../../../typography'
 import { Clickable } from '../../../../clickable'
@@ -166,10 +167,17 @@ export const AdjustRange = ({ state, adjust = 'start' }: AdjustRangeProps) => {
     onClick: updateDate(date.value, false),
   })
 
+  const showAdjust =
+    state.value !== null &&
+    state.highlightedRange !== null &&
+    equals(state.value, state.highlightedRange)
+
   return (
     <Stack
       spacing={ 2 }
-      visibility={ state.value === null ? 'hidden' : 'visible' }
+      visibility={
+        showAdjust ? 'visible' : 'hidden'
+      }
       pt="2"
     >
       <Clickable onClick={ () => setIsOpen((prev) => !prev) }>
@@ -181,7 +189,7 @@ export const AdjustRange = ({ state, adjust = 'start' }: AdjustRangeProps) => {
       <SlideFade in={ isOpen } direction="top" hideDisplay={ true }>
         { adjust === 'start' && (
           <Stack minH="91px">
-            <Lead sx={ { fontSize: '12px' } }>Move date</Lead>
+            <Lead sx={ { fontSize: '12px' } }>Move date by</Lead>
             <ButtonRow
               icon={ ArrowCircleLeftDuo }
               dates={ moveStartBack }
@@ -198,7 +206,7 @@ export const AdjustRange = ({ state, adjust = 'start' }: AdjustRangeProps) => {
         ) }
         { adjust === 'end' && (
           <Stack minH="91px">
-            <Lead sx={ { fontSize: '12px' } }>Move date</Lead>
+            <Lead sx={ { fontSize: '12px' } }>Move date by</Lead>
             <ButtonRow
               icon={ ArrowCircleLeftDuo }
               dates={ moveEndBack }

--- a/framework/lib/components/date-picker/components/calendar/quick-navigation/button-row.tsx
+++ b/framework/lib/components/date-picker/components/calendar/quick-navigation/button-row.tsx
@@ -5,6 +5,7 @@ import { MoveButton } from './move-button'
 import { Icon } from '../../../../icon'
 import { validRange } from './utils'
 import { ButtonRowProps } from './types'
+import { Box } from '../../../../box'
 
 export const ButtonRow = ({
   dates,
@@ -21,7 +22,9 @@ export const ButtonRow = ({
     { dates.map(
       (date) =>
         validRange(date.value, state) && (
-          <MoveButton { ...getMethods(date) }>{ date.label }</MoveButton>
+          <Box ml="1" display="inline">
+            <MoveButton { ...getMethods(date) }>{ date.label }</MoveButton>
+          </Box>
         )
     ) }
   </HStack>


### PR DESCRIPTION
This PR should directly help improve the Date Range picker UI/UX slightly by increasing some spacing, fixing the month select button that did not work, hiding the adjust range menu when it was supposed to be hidden, and renaming move date to move date by in the adjust menu