### PR TITLE
fix(framework): set minH and maxH

### DIFF
--- a/framework/lib/components/modal/index.ts
+++ b/framework/lib/components/modal/index.ts
@@ -3,9 +3,9 @@ export {
   ModalContent,
   ModalHeader,
   ModalFooter,
-  ModalBody,
   ModalCloseButton,
 } from '@chakra-ui/react'
 
 export * from './modal'
 export * from './types'
+export * from './modal-body'

--- a/framework/lib/components/modal/modal-body.tsx
+++ b/framework/lib/components/modal/modal-body.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import { ModalBody as ChakraModalBody, ModalBodyProps } from '@chakra-ui/react'
+
+export const ModalBody = (props: ModalBodyProps) => (
+  <ChakraModalBody minH={ props.h } maxH={ props.h } { ...props } />
+)


### PR DESCRIPTION
Previously you had to set both minH and maxH props to adjust the height of the modalBody, this was due to ModalContent, the parent container restraining
the height of ModalBody. However with this quick fix one can set h prop.

closed: DEV-10243