### PR TITLE
chore(northlight): toolbox component enhancement

### DIFF
--- a/framework/lib/components/toolbox/types.ts
+++ b/framework/lib/components/toolbox/types.ts
@@ -13,6 +13,8 @@ export interface ToolboxProps extends Omit<FlexProps, 'direction'> {
   onClose: () => void
   /** if true focuses on the first element in the toolboxcontent. */
   autoFocus?: boolean
+  /** limit the sizing of the toolbox */
+  resizeLimit?: 'half' | 'full'
 }
 
 export interface ToolboxHeaderProps extends FlexProps {


### PR DESCRIPTION
-Added some styling for resizing hold & drag
-Added one more prop for `resizeLimit` which can be 'half' and 'full' ( default is full ) so you can limit the resizing of the toolbox which can come in handy in future


https://github.com/mediatool/northlight/assets/5406237/ab1a5a32-8ce3-4fea-8fc8-7478373ad9a7

