### PR TITLE
fix(framework): fix percentage sign not showing

### DIFF
--- a/framework/lib/components/number-input/number-input-stepper.tsx
+++ b/framework/lib/components/number-input/number-input-stepper.tsx
@@ -14,31 +14,34 @@ import { NumberInputStepperProps } from './types'
 
 export const NumberInputStepper = ({
   includePercentage = false,
+  enableStepperArrows = false,
 }: NumberInputStepperProps) => (
   <ChakraNumberInputStepper>
     <HStack alignItems="center" h="full">
       { includePercentage && (
-      <Center bgColor="gray.50" borderRadius="md" boxSize="6">
-        <P>%</P>
-      </Center>
+        <Center bgColor="gray.50" borderRadius="md" boxSize="6">
+          <P>%</P>
+        </Center>
       ) }
-      <HStack alignItems="center" h="full">
-        <Divider orientation="vertical" h="50%" />
-        <NumberIncrementStepper border="none">
-          <Icon
-            as={ ChevronUpSolid }
-            color="icon.input-stepper.default"
-            boxSize={ 4 }
-          />
-        </NumberIncrementStepper>
-        <NumberDecrementStepper>
-          <Icon
-            as={ ChevronDownSolid }
-            color="icon.input-stepper.default"
-            boxSize={ 4 }
-          />
-        </NumberDecrementStepper>
-      </HStack>
+      { enableStepperArrows && (
+        <HStack alignItems="center" h="full">
+          <Divider orientation="vertical" h="50%" />
+          <NumberIncrementStepper border="none">
+            <Icon
+              as={ ChevronUpSolid }
+              color="icon.input-stepper.default"
+              boxSize={ 4 }
+            />
+          </NumberIncrementStepper>
+          <NumberDecrementStepper>
+            <Icon
+              as={ ChevronDownSolid }
+              color="icon.input-stepper.default"
+              boxSize={ 4 }
+            />
+          </NumberDecrementStepper>
+        </HStack>
+      ) }
     </HStack>
   </ChakraNumberInputStepper>
 )

--- a/framework/lib/components/number-input/number-input.tsx
+++ b/framework/lib/components/number-input/number-input.tsx
@@ -58,9 +58,10 @@ export const NumberInput = ({
       { ...rest }
     >
       <NumberInputField onChange={ handleChange } />
-      { enableStepperArrows && (
-      <NumberInputStepper includePercentage={ onlyAcceptPercentage } />
-      ) }
+      <NumberInputStepper
+        includePercentage={ onlyAcceptPercentage }
+        enableStepperArrows={ enableStepperArrows }
+      />
     </ChakraNumberInput>
   )
 }

--- a/framework/lib/components/number-input/types.ts
+++ b/framework/lib/components/number-input/types.ts
@@ -33,4 +33,5 @@ export type NumberInputFieldProps =
 
 export interface NumberInputStepperProps {
   includePercentage?: boolean
+  enableStepperArrows?: boolean
 }


### PR DESCRIPTION
closed DEV-10277

For the Number Input with OnlyAcceptPercentage set to true: 
Before:
![Screenshot 2023-12-01 at 16 06 28](https://github.com/mediatool/northlight/assets/90923099/bc32166c-6719-42f0-96cf-0e1f723e6997)


After:
![Screenshot 2023-12-01 at 16 06 44](https://github.com/mediatool/northlight/assets/90923099/5c9d2014-678f-4e71-8db4-016e9b8b9f2e)

