### PR TITLE
chore(framework): fix colors and example presentation for status pin

### DIFF
--- a/framework/lib/components/pin-input/types.ts
+++ b/framework/lib/components/pin-input/types.ts
@@ -1,6 +1,6 @@
 import { PinInputProps as ChakraPinInputProps } from '@chakra-ui/react'
 
-export type PinVariant = 'green' | 'yellow' | 'gray' | 'red'
+export type PinVariant = 'green' | 'running' | 'yellow' | 'inProgress' | 'gray' | 'notExecuted' | 'red' | 'rejected'
 export type PinSize = 'sm' | 'md' | 'lg'
 export type PinSizeTuple = [ number, number ]
 

--- a/framework/lib/components/status-pin/pin-variant-map.ts
+++ b/framework/lib/components/status-pin/pin-variant-map.ts
@@ -2,8 +2,12 @@ import { Color, ColorGrade } from '../../types'
 import { PinVariant } from '../pin-input/types'
 
 export const pinVariantMap: Record<PinVariant, `${Color}.${ColorGrade}`> = {
-  green: 'green.300',
-  yellow: 'yellow.300',
+  green: 'green.500',
+  running: 'green.500',
+  yellow: 'yellow.600',
+  inProgress: 'yellow.600',
   gray: 'gray.300',
-  red: 'red.400',
+  notExecuted: 'gray.300',
+  red: 'red.500',
+  rejected: 'red.500',
 }

--- a/framework/lib/components/status-pin/status-pin.tsx
+++ b/framework/lib/components/status-pin/status-pin.tsx
@@ -9,7 +9,25 @@ import { StatusPinProps } from './types'
  * @see {@link https://northlight/reference/status-pin}
  *
  * @example
- * (? <StatusPin variant="green" /> ?)
+ * (?
+ * +
+ * const variants = ["running", "inProgress", "notExecuted", "rejected"]
+ * const sizes = ["sm", "md", "lg"]
+ * const Example = () => {
+ *     return <Stack>
+ *         { sizes.map((size) => (
+ *         <HStack spacing={ 4 }>
+ *             {
+ *                 variants.map((variant) => (
+ *                 <StatusPin variant={variant} size={size} />
+ *                 ))
+ *             }
+ *             </HStack>
+ *         ))}
+ *         </Stack>
+ * }
+ * render(<Example/>)
+ * ?)
  *
  */
 export const StatusPin = ({ size = 'md', variant }: StatusPinProps) => {


### PR DESCRIPTION
change colors to have more contrast to background, add new variants and add all variants to example presentation in northlight

Closes: DEV-10293

![Screenshot 2023-12-06 at 11 22 57](https://github.com/mediatool/northlight/assets/106168179/859d9f8f-6f1c-4e77-9442-3ce313919a76)