### PR TITLE
chore(framework): change header to H4 in modal and toolbox

### DIFF
--- a/framework/lib/components/modal/index.ts
+++ b/framework/lib/components/modal/index.ts
@@ -9,3 +9,4 @@ export {
 export * from './modal'
 export * from './types'
 export * from './modal-body'
+export * from './modal-base'

--- a/framework/lib/components/modal/modal-base.tsx
+++ b/framework/lib/components/modal/modal-base.tsx
@@ -1,0 +1,22 @@
+import { Modal as ChakraModal, ModalCloseButton, ModalContent, ModalOverlay } from '@chakra-ui/react'
+import React from 'react'
+import { ModalProps } from './types'
+
+export const ModalBase = ({
+  isCentered = true,
+  children,
+  ...rest
+}: ModalProps) => (
+  <ChakraModal
+    isCentered={ isCentered }
+    scrollBehavior="inside"
+    motionPreset="slideInBottom"
+    { ...rest }
+  >
+    <ModalOverlay />
+    <ModalContent data-testid="modal-test-id">
+      <ModalCloseButton data-testid="modal-test-button-id" />
+      { children }
+    </ModalContent>
+  </ChakraModal>
+)

--- a/framework/lib/components/modal/modal.tsx
+++ b/framework/lib/components/modal/modal.tsx
@@ -1,34 +1,11 @@
 import React from 'react'
-import {
-  Modal as ChakraModal,
-  ModalCloseButton,
-  ModalContent,
-  ModalOverlay,
-} from '@chakra-ui/react'
 import { ModalProps } from './types'
+import { ModalBase } from './modal-base'
 
 /**
  * @see {@link https://northlight.dev/reference/modal}
  *
  * */
-export const ModalBase = ({
-  isCentered = true,
-  children,
-  ...rest
-}: ModalProps) => (
-  <ChakraModal
-    isCentered={ isCentered }
-    scrollBehavior="inside"
-    motionPreset="slideInBottom"
-    { ...rest }
-  >
-    <ModalOverlay />
-    <ModalContent data-testid="modal-test-id">
-      <ModalCloseButton data-testid="modal-test-button-id" />
-      { children }
-    </ModalContent>
-  </ChakraModal>
-)
 
 export const Modal = ({
   stayMountedOnClose = false,

--- a/framework/lib/components/toolbox/toolbox-header.tsx
+++ b/framework/lib/components/toolbox/toolbox-header.tsx
@@ -3,7 +3,7 @@ import { useMultiStyleConfig } from '@chakra-ui/system'
 import { CloseButton } from '../close-button'
 import { Flex } from '../flex'
 import { ToolboxHeaderProps } from './types'
-import { H3 } from '../typography'
+import { H4 } from '../typography'
 
 /**
  * @see Toolbox
@@ -19,7 +19,7 @@ export const ToolboxHeader = ({
 
   return (
     <Flex sx={ header } { ...rest }>
-      { typeof children === 'string' ? <H3>{ children }</H3> : children }
+      { typeof children === 'string' ? <H4>{ children }</H4> : children }
       <CloseButton
         aria-label="Close toolbox"
         position="fixed"

--- a/framework/lib/theme/components/modal/index.ts
+++ b/framework/lib/theme/components/modal/index.ts
@@ -13,7 +13,7 @@ export const Modal: ComponentMultiStyleConfig = {
   },
   baseStyle: ({ theme }) => {
     const {
-      typography: { headings: { h3 } },
+      typography: { headings: { h4 } },
     } = theme
     return ({
       overlay: {
@@ -29,7 +29,7 @@ export const Modal: ComponentMultiStyleConfig = {
         borderRadius: 'modal.dialog',
       },
       header: {
-        fontSize: h3.fontSize,
+        fontSize: h4.fontSize,
         paddingTop: 'paddingTop.modal.header',
         paddingBottom: 'paddingBottom.modal.header',
         border: 'modal.header',


### PR DESCRIPTION
change header to H4 in modal and toolbox

Closes: DEV-10299

<img width="377" alt="Screenshot 2023-12-08 at 12 00 49" src="https://github.com/mediatool/northlight/assets/106168179/56107a7e-dea1-4092-8483-5c10a7eab941">
<img width="499" alt="Screenshot 2023-12-08 at 12 01 28" src="https://github.com/mediatool/northlight/assets/106168179/de04224c-0bb0-49db-9ea4-28e5c058b1af">
