### PR TITLE
fix(northlight): edited padding tokens in the modal header

### DIFF
--- a/tokens/lib/tokens.json
+++ b/tokens/lib/tokens.json
@@ -4286,7 +4286,7 @@
             "type": "spacing"
           },
           "header": {
-            "value": "{spacing.4}",
+            "value": "{spacing.5}",
             "type": "spacing"
           }
         }
@@ -4302,7 +4302,7 @@
             "type": "spacing"
           },
           "header": {
-            "value": "{spacing.4}",
+            "value": "{spacing.5}",
             "type": "spacing"
           }
         },


### PR DESCRIPTION
Edited tokens for bottom and top paddings in the modal header from 1 rem to 1.25 rem to keep the close button centered after changing the heading style from h3 to h4