### PR TITLE
fix(framework): do not override icon size

### DIFF
--- a/framework/lib/components/icon-button/icon-button.tsx
+++ b/framework/lib/components/icon-button/icon-button.tsx
@@ -32,7 +32,7 @@ export const IconButton = forwardRef(({
   ...rest
 }: IconButtonProps, ref: any) => {
   const IconComponent = icon ?? children as JSX.Element
-  const IconWithSize = cloneElement(IconComponent, { size: rest.size })
+  const IconWithSize = cloneElement(IconComponent, { size: IconComponent.props.size ?? rest.size })
   return (
     <ChakraIconButton
       variant={ variant }


### PR DESCRIPTION
previousely you could not set a custom size for the icon in an iconbutton as it would be overriden, this should clear up confusion, so if a size for the icon is specified that will be used, and if not then the size of the icon button will be used instead