### PR TITLE
fix(norhtlight/icons): stages icon viewBox fix

### DIFF
--- a/icons/assets/stages-duo.svg
+++ b/icons/assets/stages-duo.svg
@@ -1,4 +1,4 @@
-<svg width="20" height="8" viewBox="0 0 20 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path opacity="0.4" d="M5 7C6.65685 7 8 5.65685 8 4C8 2.34315 6.65685 1 5 1C3.34315 1 2 2.34315 2 4C2 5.65685 3.34315 7 5 7Z" fill="#111111" stroke="#111111" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M15 7C16.6569 7 18 5.65685 18 4C18 2.34315 16.6569 1 15 1C13.3431 1 12 2.34315 12 4C12 5.65685 13.3431 7 15 7Z" stroke="#111111" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M17 15C18.6569 15 20 13.6569 20 12C20 10.3431 18.6569 9 17 9C15.3431 9 14 10.3431 14 12C14 13.6569 15.3431 15 17 15Z" stroke="#1B1C1E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path opacity="0.4" d="M7 15C8.65685 15 10 13.6569 10 12C10 10.3431 8.65685 9 7 9C5.34315 9 4 10.3431 4 12C4 13.6569 5.34315 15 7 15Z" fill="#1B1C1E" stroke="#1B1C1E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/icons/assets/stages-solid.svg
+++ b/icons/assets/stages-solid.svg
@@ -1,4 +1,4 @@
-<svg width="20" height="8" viewBox="0 0 20 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M5 7C6.65685 7 8 5.65685 8 4C8 2.34315 6.65685 1 5 1C3.34315 1 2 2.34315 2 4C2 5.65685 3.34315 7 5 7Z" fill="#111111" stroke="#111111" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M15 7C16.6569 7 18 5.65685 18 4C18 2.34315 16.6569 1 15 1C13.3431 1 12 2.34315 12 4C12 5.65685 13.3431 7 15 7Z" stroke="#111111" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M17 15C18.6569 15 20 13.6569 20 12C20 10.3431 18.6569 9 17 9C15.3431 9 14 10.3431 14 12C14 13.6569 15.3431 15 17 15Z" stroke="#111111" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7 15C8.65685 15 10 13.6569 10 12C10 10.3431 8.65685 9 7 9C5.34315 9 4 10.3431 4 12C4 13.6569 5.34315 15 7 15Z" fill="#1B1C1E" stroke="#1B1C1E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>


### PR DESCRIPTION
fixes the issue with the stages icon aligning top in in viewBox.

From this:
<img width="306" alt="Screenshot 2023-12-18 at 14 18 01" src="https://github.com/mediatool/northlight/assets/5406237/5ac35577-da54-4b8b-bb37-b703784c299c">


To this:
<img width="717" alt="Screenshot 2023-12-18 at 14 17 34" src="https://github.com/mediatool/northlight/assets/5406237/7a669ffa-2bfb-4af7-8c99-c7c3767d42c4">
