### PR TITLE
chore (northlight): new color tokens for text

### DIFF
--- a/tokens/lib/tokens.json
+++ b/tokens/lib/tokens.json
@@ -3487,12 +3487,20 @@
             "value": "{st.color.inverted}",
             "type": "color"
           },
-          "link": {
+          "default": {
             "value": "{st.color.brand}",
             "type": "color"
           },
+          "success": {
+            "value": "{st.color.inverted}",
+            "type": "color"
+          },
+          "link": {
+            "value": "{st.color.text.link.default}",
+            "type": "color"
+          },
           "link-hover": {
-            "value": "{st.color.brand}{alpha.hover-full}",
+            "value": "{st.color.text.link.hover}",
             "type": "color"
           }
         },

--- a/tokens/lib/tokens.json
+++ b/tokens/lib/tokens.json
@@ -1944,6 +1944,20 @@
               "value": "{color.blue.400}{alpha.hover-full}",
               "type": "color"
             }
+          },
+          "over-alt": {
+            "brand": {
+              "value": "{color.mono.white}",
+              "type": "color"
+            },
+            "danger": {
+              "value": "{color.mono.black}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{color.mono.black}",
+              "type": "color"
+            }
           }
         },
         "chart": {
@@ -2624,6 +2638,20 @@
             },
             "hover": {
               "value": "{color.blue.500}{alpha.hover-full}",
+              "type": "color"
+            }
+          },
+          "over-alt": {
+            "brand": {
+              "value": "{st.color.brand}",
+              "type": "color"
+            },
+            "danger": {
+              "value": "{color.red.600}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{color.green.600}",
               "type": "color"
             }
           }
@@ -3474,25 +3502,37 @@
           "value": "{st.color.inverted}",
           "type": "color"
         },
-        "subdued": {
-          "value": "{st.color.subdued}",
-          "type": "color"
-        },
         "inverted": {
           "value": "{st.color.base}",
           "type": "color"
         },
+        "subdued": {
+          "value": "{st.color.subdued}",
+          "type": "color"
+        },
+        "brand": {
+          "value": "{st.color.brand}",
+          "type": "color"
+        },
+        "success": {
+          "value": "{st.color.success}",
+          "type": "color"
+        },
+        "danger": {
+          "value": "{st.color.destructive}",
+          "type": "color"
+        },
         "button": {
-          "danger": {
-            "value": "{st.color.inverted}",
+          "default": {
+            "value": "{st.color.text.over-alt.brand}",
             "type": "color"
           },
-          "default": {
-            "value": "{st.color.brand}",
+          "danger": {
+            "value": "{st.color.text.over-alt.danger}",
             "type": "color"
           },
           "success": {
-            "value": "{st.color.inverted}",
+            "value": "{st.color.text.over-alt.success}",
             "type": "color"
           },
           "link": {
@@ -3501,6 +3541,14 @@
           },
           "link-hover": {
             "value": "{st.color.text.link.hover}",
+            "type": "color"
+          },
+          "aiSubdued": {
+            "value": "{st.color.ai}",
+            "type": "color"
+          },
+          "brandSubdued": {
+            "value": "{st.color.brand}",
             "type": "color"
           }
         },


### PR DESCRIPTION
Added an alternate set of tokens for text on a coloured background ('over-alt') in web app and tott skins. Created specific component tokens for text in button's variants. Added standard brand, success and danger tokens for text on a white background