### PR TITLE
fix(framework): fix broken token colors

### DIFF
--- a/framework/lib/theme/components/badge/index.ts
+++ b/framework/lib/theme/components/badge/index.ts
@@ -1,4 +1,5 @@
-import { ComponentSingleStyleConfig } from '@chakra-ui/react'
+import { ComponentSingleStyleConfig, useToken } from '@chakra-ui/react'
+import { getContrastColor } from '../../../utils'
 
 export const Badge: ComponentSingleStyleConfig = {
   baseStyle: ({ colorScheme, theme: { colors } }) => {
@@ -19,11 +20,10 @@ export const Badge: ComponentSingleStyleConfig = {
       const bgColor = colorScheme === 'mediatoolBlue'
         ? colors[colorScheme][500]
         : colors[colorScheme] && colors[colorScheme][500]
-      const textColor = colorScheme === 'yellow' ? 'mono.black' : 'mono.white'
 
       return {
         bgColor,
-        color: textColor,
+        color: getContrastColor(bgColor ?? useToken('colors', colorScheme)),
       }
     },
     outline: ({ colorScheme, theme: { colors } }) => {

--- a/framework/lib/theme/components/button/index.ts
+++ b/framework/lib/theme/components/button/index.ts
@@ -39,7 +39,6 @@ export const Button: ComponentSingleStyleConfig = {
   variants: {
     default: ({ theme: { colors: color } }) => ({
       bgColor: color.background.button.default,
-      color: color.text.button.default,
       _hover: {
         bgColor: color.background.button['default-hover'],
       },

--- a/framework/lib/theme/components/tag/index.ts
+++ b/framework/lib/theme/components/tag/index.ts
@@ -1,4 +1,5 @@
-import { ComponentMultiStyleConfig } from '@chakra-ui/react'
+import { ComponentMultiStyleConfig, useToken } from '@chakra-ui/react'
+import { getContrastColor } from '../../../utils'
 
 export const Tag: ComponentMultiStyleConfig = {
   parts: [ 'container' ],
@@ -25,17 +26,21 @@ export const Tag: ComponentMultiStyleConfig = {
     },
   },
   variants: {
-    solid: ({ theme: { colors }, colorScheme }) => ({
+    solid: ({ theme: { colors, bgColor }, colorScheme }) => ({
       container: {
-        bgColor: colors[colorScheme] && colors[colorScheme][500]
-          ? colors[colorScheme][500] : colorScheme,
-        color: colorScheme === 'yellow' ? 'mono.black' : 'mono.white',
+        bgColor:
+          colors[colorScheme] && colors[colorScheme][500]
+            ? colors[colorScheme][500]
+            : colorScheme,
+        color: getContrastColor(bgColor ?? useToken('colors', colorScheme)),
       },
     }),
     subtle: ({ theme: { colors }, colorScheme }) => ({
       container: {
-        bgColor: colors[colorScheme] && colors[colorScheme][100]
-          ? colors[colorScheme][100] : colorScheme,
+        bgColor:
+          colors[colorScheme] && colors[colorScheme][100]
+            ? colors[colorScheme][100]
+            : colorScheme,
         color: 'mono.black',
       },
     }),


### PR DESCRIPTION
This PR fixes two recent bugs:

1. Random blue color – the default button variant was recently changed to have color set to blue.500, since a lot of components, especially text and icons are wrapped in a <Button /> this made them blue

2. Badge and Tag weird colors. The text color of all badge and tag children were set to white unless colorScheme was set to yellow. Using getContrastColor together with useToken instead ensures that the correct text color is used

![E6D4BF10-3B1D-44A0-859E-FACF916DAEBD](https://github.com/mediatool/northlight/assets/90923099/4d0d597f-0638-46f6-9169-c6fae8a6b6e2)
![0097477E-95F4-4F16-AD16-40F3D38F5D32_4_5005_c](https://github.com/mediatool/northlight/assets/90923099/4fca3b2d-e3bf-43f8-b677-f5441d88dca9)
![46E29FA3-F06D-4B16-8648-3E85249ADA7B_4_5005_c](https://github.com/mediatool/northlight/assets/90923099/ddc6bc69-3e36-4130-a522-446965f72f11)
