### PR TITLE
chore(norhtlight): toast, alert, and tooltip updates

### DIFF
--- a/framework/lib/components/alert/types.ts
+++ b/framework/lib/components/alert/types.ts
@@ -1,6 +1,6 @@
 import { AlertProps as ChakraAlertProps } from '@chakra-ui/react'
 
-export type AlertVariants = 'success' | 'warning' | 'error' | 'info' | 'danger' | 'ai'
+export type AlertVariants = 'success' | 'warning' | 'error' | 'info' | 'danger' | 'ai' | 'default' | 'ghost'
 
 export interface AlertProps extends ChakraAlertProps {
   variant?: AlertVariants

--- a/framework/lib/components/toast/toast.tsx
+++ b/framework/lib/components/toast/toast.tsx
@@ -16,10 +16,12 @@ import { Label, P } from '../typography'
  * (?
  *
         <HStack spacing={ 4 }>
+          <Toast variant="default" title="default" />
           <Toast variant="success" title="success" />
           <Toast variant="warning" title="warning" />
-          <Toast variant="info" title="info" />
           <Toast variant="error" title="error" />
+          <Toast variant="info" title="info" />
+          <Toast variant="ai" title="mtGPT" />
         </HStack>
  * ?)
  *
@@ -30,27 +32,36 @@ export const Toast = ({
   description = '',
   onClose,
   ...rest
-}: ToastProps) => (
-  <ChakraAlert
-    variant={ variant }
-    data-testid="toast-test"
-    { ...rest }
-  >
-    <HStack alignItems="flex-start">
-      <Icon as={ toastIconMap[variant] } color={ `icon.toast.${variant}` } boxSize={ 6 } />
-      <Stack spacing={ 0 } alignItems="flex-start">
-        { title && <Label size="md">{ title }</Label> }
-        { description && (
-          <P>{ description }</P>
+}: ToastProps) => {
+  const icon = toastIconMap[variant]
+
+  return (
+    <ChakraAlert
+      variant={ variant }
+      data-testid="toast-test"
+      { ...rest }
+    >
+      <HStack alignItems="flex-start">
+        { icon && (
+        <Icon
+          as={ icon }
+          color={ `icon.toast.${variant}` }
+          boxSize={ 6 }
+        />
         ) }
-      </Stack>
-      <CloseButton
-        size="sm"
-        onClick={ onClose }
-        position="absolute"
-        insetEnd={ 1 }
-        top={ 1 }
-      />
-    </HStack>
-  </ChakraAlert>
-)
+        <Stack spacing={ 0 } alignItems="flex-start">
+          { title && <Label size="md">{ title }</Label> }
+          { description && <P>{ description }</P> }
+        </Stack>
+
+        <CloseButton
+          size="sm"
+          onClick={ onClose }
+          position="absolute"
+          insetEnd={ 1 }
+          top={ 1 }
+        />
+      </HStack>
+    </ChakraAlert>
+  )
+}

--- a/framework/lib/components/toast/types.ts
+++ b/framework/lib/components/toast/types.ts
@@ -12,8 +12,5 @@ export interface UseToastOptions extends UseChakraToastOptions {
   variant?: AlertVariants
   title?: string
   description?: string
-  /** if set to true and if there is already another toast visible,
-   *  it will update the information on the current visible toast rather
-   *  than displaying a new one on top of the previous one */
   replacePreviousToast?: boolean
 }

--- a/framework/lib/components/tooltip/tooltip.tsx
+++ b/framework/lib/components/tooltip/tooltip.tsx
@@ -2,17 +2,13 @@ import React from 'react'
 import {
   Tooltip as ChakraTooltip,
   HStack,
-  TooltipProps,
   VStack,
 } from '@chakra-ui/react'
-import { Label } from '../typography'
+import { Label, P } from '../typography'
 import { Icon } from '../icon'
 import { AlertVariants } from '../alert'
-import { toastIconMap } from '../types'
-
-export type OurTooltipProps = TooltipProps & {
-  description?: string
-}
+import { toastIconMap } from '../types/toastIconMap'
+import { OurTooltipProps } from './types'
 
 /**
  * A tooltip is a brief, informative message that appears when a user interacts with an element.
@@ -21,16 +17,17 @@ export type OurTooltipProps = TooltipProps & {
  * @example
  * (?
  * <HStack>
- *    <Tooltip label="Here’s a regular tooltip with some text
+ *    <Tooltip
+ *      description="Here’s a regular tooltip with some with icon
  *      inside of it that’s supposed to be substantially large.">
- *      <Badge>Default</Badge>
+ *      <Badge>ICON</Badge>
  *    </Tooltip>
  *    <Tooltip
- *       variant="light"
- *       description="Here’s a regular tooltip with some text
+ *       hasIcon={ false }
+ *       description="Here’s a regular tooltip with some text without icon
  *      inside of it that’s supposed to be substantially large."
  *    >
- *      <Badge>Light</Badge>
+ *      <Badge>NOICON</Badge>
  *    </Tooltip>
  * </HStack>
  * ?)
@@ -107,7 +104,7 @@ export type OurTooltipProps = TooltipProps & {
  *        <Tooltip
  *          variant="ai"
  *          description="This is an AI message">
- *        <Badge>AI</Badge>
+ *        <Badge colorScheme="teal" variant="subtle">AI</Badge>
  *        </Tooltip>
  *        <Tooltip
  *          variant="ai"
@@ -115,50 +112,61 @@ export type OurTooltipProps = TooltipProps & {
  *          description="This is an AI message with a title and an icon
  *          that’s supposed to be substantially large."
  *          >
- *          <Badge>AI</Badge>
+ *          <Badge colorScheme="teal" variant="subtle">AI</Badge>
+ *        </Tooltip>
+ *      </VStack>
+ *      <VStack>
+ *        <Tooltip
+ *          variant="ghost"
+ *          description="This is an clean message">
+ *        <Badge>Ghost</Badge>
+ *        </Tooltip>
+ *        <Tooltip
+ *          variant="ghost"
+ *          title="Please check fields"
+ *          description="This is an clean message with a title and an icon
+ *          that’s supposed to be substantially large."
+ *          >
+ *          <Badge>Ghost</Badge>
  *        </Tooltip>
  *      </VStack>
  * </HStack>
  * ?)
  */
 
-export const Tooltip = ({
+export const Tooltip: React.FC<OurTooltipProps> = ({
   variant = 'default',
   hasArrow = true,
   title = '',
   description = '',
+  hasIcon = 'true',
   ...rest
-}: OurTooltipProps) => {
-  const iconVariant = variant as AlertVariants
-  // const iconVariant = variant as TooltipIconVariants
+}) => {
+  const iconVariant: AlertVariants = variant as AlertVariants
+  const icon = toastIconMap[iconVariant]
 
   const TooltipContent = (
     <HStack alignItems="flex-start">
-      { title !== '' && iconVariant in toastIconMap ? (
-        <VStack spacing={ 0 } alignItems="flex-start">
-          <HStack>
-            <Icon
-              as={ toastIconMap[iconVariant] }
-              color={ `icon.toast.${iconVariant}` }
-            />
-            <Label size="md">{ title }</Label>
-          </HStack>
-          <Label sx={ { fontWeight: 400 } }>{ description }</Label>
-        </VStack>
-      )
-        : (
-          <Label variant="14">{ description }</Label>
-        ) }
+      { hasIcon && <Icon as={ icon } color={ `icon.toast.${iconVariant}` } /> }
+      <VStack spacing={ 0 } alignItems="flex-start">
+        <Label size="sm">{ title }</Label>
+        <P
+          variant="14"
+          sx={ {
+            color: !variant || variant === 'ai' || variant === 'default' ? 'text.inverted' : undefined,
+          } }
+        >
+          { description }
+        </P>
+      </VStack>
     </HStack>
   )
-
   return (
     <ChakraTooltip
-      variant={ variant }
       hasArrow={ hasArrow }
-      title={ title }
-      description={ description }
-      label={ title !== '' ? TooltipContent : description }
+      hasIcon={ hasIcon }
+      label={ title || description ? TooltipContent : undefined }
+      variant={ variant }
       { ...rest }
     />
   )

--- a/framework/lib/components/tooltip/types.ts
+++ b/framework/lib/components/tooltip/types.ts
@@ -1,0 +1,9 @@
+import { TooltipProps as ChakraTooltipProps } from '@chakra-ui/react'
+
+export type TooltipVariants = 'success' | 'warning' | 'error' | 'info' | 'danger' | 'ai' | 'default' | 'ghost'
+
+export interface OurTooltipProps extends ChakraTooltipProps {
+  variant?: TooltipVariants
+  description?: string
+  hasIcon?: boolean
+}

--- a/framework/lib/components/types/toastIconMap/index.ts
+++ b/framework/lib/components/types/toastIconMap/index.ts
@@ -4,6 +4,7 @@ import {
   BellSolid,
   BrightnessSolid,
   CheckCircleSolid,
+  HelpCircleSolid,
 } from '@northlight/icons'
 import { AlertVariants } from '../../alert/types'
 
@@ -14,4 +15,6 @@ export const toastIconMap: Record<AlertVariants, any> = {
   danger: AlertCircleSolid,
   info: BellSolid,
   ai: BrightnessSolid,
+  default: HelpCircleSolid,
+  ghost: HelpCircleSolid,
 }

--- a/framework/lib/theme/components/alert/index.ts
+++ b/framework/lib/theme/components/alert/index.ts
@@ -37,5 +37,26 @@ export const Alert: ComponentMultiStyleConfig = {
         color: color.text.toast.error,
       },
     }),
+    ai: ({ theme: { colors: color } }) => ({
+      container: {
+        bgColor: color.bg.ai.default,
+        color: color.text.inverted,
+      },
+    }),
+    default: ({ theme: { colors: color } }) => ({
+      container: {
+        bgColor: color.bg.layer,
+        color: color.text.default,
+      },
+    }),
+    ghost: ({ theme: { colors: color } }) => ({
+      container: {
+        bgColor: color.bg.base,
+        color: color.text.default,
+        borderWidth: 'xs',
+        borderColor: color.border.default,
+        borderStyle: 'solid',
+      },
+    }),
   },
 }

--- a/framework/lib/theme/components/tooltip/index.ts
+++ b/framework/lib/theme/components/tooltip/index.ts
@@ -16,28 +16,24 @@ export const Tooltip: ComponentSingleStyleConfig = {
     [$arrowBg.variable]: color.background.tooltip.default,
   }),
   variants: {
-    light: ({ theme: { colors: color, borders } }) => ({
-      color: color.text.over.success,
-      border: `
-        ${color.border.default} 
-        ${borders['1px']}
-        `,
-      bgColor: color.bg.base,
-      [$arrowBg.variable]: color.bg.base,
-      [$arrowBorder.variable]: color.border.default,
+    default: ({ theme: { colors: color } }) => ({
+      bgColor: 'bg.tertiary.default',
+      color: color.text.inverted,
+      [$arrowBg.variable]: color.bg.tertiary.default,
+      [$arrowBorder.variable]: color.bg.tertiary.default,
     }),
     success: ({ theme: { colors: color } }) => ({
-      color: color.text.over.success,
+      color: 'text.over.success',
       bgColor: 'success-alt',
       [$arrowBg.variable]: color['success-alt'],
     }),
     info: ({ theme: { colors: color } }) => ({
-      color: color.text.over.brand,
+      color: 'text.over.brand',
       bgColor: 'brand-alt',
       [$arrowBg.variable]: color['brand-alt'],
     }),
     ghost: ({ theme: { colors: color } }) => ({
-      color: color.text.default,
+      color: 'text.default',
       bgColor: color.bg.base,
       borderWidth: 'xs',
       borderColor: color.border.default,
@@ -46,19 +42,19 @@ export const Tooltip: ComponentSingleStyleConfig = {
       [$arrowBg.variable]: color.bg.base,
     }),
     warning: ({ theme: { colors: color } }) => ({
-      color: color.text.over.info,
+      color: 'text.over.warning',
       bgColor: color['info-alt'],
       [$arrowBg.variable]: color['info-alt'],
     }),
     danger: ({ theme: { colors: color } }) => ({
-      color: color.text.over.error,
+      color: 'text.over.error',
       bgColor: color['destructive-alt'],
       [$arrowBg.variable]: color['destructive-alt'],
     }),
     ai: ({ theme: { colors: color } }) => ({
-      color: color.text.inverted,
       bgColor: color.bg.ai.default,
       [$arrowBg.variable]: color.bg.ai.default,
+
     }),
   },
 }


### PR DESCRIPTION
A couple of `toast`, `alert`, and `tooltip` component updates, including:

- Resolved TypeErrors in both light and dark modes caused by undefined properties.
- Addressed console errors related to unassigned or unidentified icons in the `toastIconMap`.
- Updated and correctly assigned design tokens.
- Revised styles for specific component variants.
- Implemented new `ai` and `ghost` variants, precisely matching the latest updates in the Figma component library (1:1 correspondence).
- Enhanced type definitions for the `tooltip`, and updated the types for both `tooltip` and `alert` components.
- `tooltip` now has `hasIcon={ true / false }` option
- Various minor layout fixes in the mentioned components.

closes: DEV-10296

**Sneak peek:**
<img width="464" alt="Screenshot 2024-01-18 at 21 47 47" src="https://github.com/mediatool/northlight/assets/5406237/486d2d50-9476-455b-b577-6dd6569e36eb">
<img width="849" alt="Screenshot 2024-01-18 at 21 43 23" src="https://github.com/mediatool/northlight/assets/5406237/a5cae255-8fba-4723-be95-b46136f605e8">
<img width="959" alt="Screenshot 2024-01-18 at 21 34 13" src="https://github.com/mediatool/northlight/assets/5406237/09d2895e-155c-4d85-a68f-68ca615a6817">
<img width="995" alt="Screenshot 2024-01-18 at 21 34 02" src="https://github.com/mediatool/northlight/assets/5406237/2e353375-f36b-4480-b79b-2d716ebf23bd">
