### PR TITLE
fix(framework): add jsx to tooltip type

### DIFF
--- a/framework/lib/components/tooltip/tooltip.tsx
+++ b/framework/lib/components/tooltip/tooltip.tsx
@@ -29,6 +29,29 @@ import { OurTooltipProps } from './types'
  *    >
  *      <Badge>NOICON</Badge>
  *    </Tooltip>
+ *    <Tooltip
+ *      hasIcon={ false }
+ *      description={
+ *        <Box>
+ *          <Text>
+ *            Some text
+ *          </Text>
+ *          <UnorderedList>
+ *            <ListItem>
+ *              List item 1
+ *            </ListItem>
+ *            <ListItem>
+ *              List item 2
+ *            </ListItem>
+ *            <ListItem>
+ *              List item 3
+ *            </ListItem>
+ *          </UnorderedList>
+ *        </Box>
+ *      }
+ *    >
+ *      <Badge>With JSX content</Badge>
+ *    </Tooltip>
  * </HStack>
  * ?)
  *

--- a/framework/lib/components/tooltip/types.ts
+++ b/framework/lib/components/tooltip/types.ts
@@ -4,6 +4,6 @@ export type TooltipVariants = 'success' | 'warning' | 'error' | 'info' | 'danger
 
 export interface OurTooltipProps extends ChakraTooltipProps {
   variant?: TooltipVariants
-  description?: string
+  description?: React.ReactNode
   hasIcon?: boolean
 }


### PR DESCRIPTION
changed tooltip type to accept JSX and also added an example
![Screenshot 2024-02-01 at 14 33 54](https://github.com/mediatool/northlight/assets/81630176/8d8e39b5-693c-49b5-86a9-35643f343065)
