### PR TITLE
fix(framework): select is clearable

### DIFF
--- a/framework/lib/components/select/select.tsx
+++ b/framework/lib/components/select/select.tsx
@@ -147,6 +147,7 @@ export const Select = forwardRef(<T extends Option, K extends boolean = false>({
   'data-testid': testId,
   customOption = null,
   customTag = null,
+  isClearable = false,
   value,
   icon,
   ...rest
@@ -184,7 +185,7 @@ export const Select = forwardRef(<T extends Option, K extends boolean = false>({
         useBasicStyles={ true }
         closeMenuOnSelect={ !isMulti }
         hideSelectedOptions={ false }
-        isClearable={ false }
+        isClearable={ isClearable }
         onChange={ handleChange }
         selectedOptionStyle="check"
         chakraStyles={ customSelectStyles }


### PR DESCRIPTION
Clearing the value for select component with isClearable set to true and isMulti set to false didn't work. Therefor I passed the prop isClearable, default to false, to ChakraReactSelect.

Closes: DEV-11057