### PR TITLE
fix(framework-createable-select-dropdown): reset selection

### DIFF
--- a/framework/lib/components/createable-select-dropdown/types.ts
+++ b/framework/lib/components/createable-select-dropdown/types.ts
@@ -5,12 +5,12 @@ export interface CreationOption extends Option {
   isCreation: boolean
 }
 
-export interface CreatableSelectDropdownProps {
+export interface CreatableSelectDropdownProps<T extends string = string> {
   /**
    * An array of "Option" objects that represents the initial options available in the dropdown.
    * Each "Option" object must have a "label" and a "value" property (both strings).
    */
-  standardOptions: Option[]
+  standardOptions: Option<T>[]
 
   /**
    * A callback function that is called whenever the selected option changes.
@@ -55,5 +55,5 @@ export interface CreatableSelectDropdownProps {
   /**
    * Value of the initially selected option.
    */
-  initialValue?: string
+  initialValue?: T
 }

--- a/framework/lib/components/select/types.ts
+++ b/framework/lib/components/select/types.ts
@@ -15,9 +15,9 @@ import { InputFieldProps } from '../../types'
 export type { SingleValue, MultiValue } from 'chakra-react-select'
 
 type Size = 'sm' | 'md' | 'lg'
-export interface Option {
+export interface Option<T extends string = string> {
   label: string
-  value: string
+  value: T
 }
 
 export interface SelectProps<T, K extends boolean>


### PR DESCRIPTION
the selection will now be reset if the user is clicking outside the select box, if the currently selected option is a creation option.

https://github.com/mediatool/northlight/assets/81630176/950a5696-b3e0-4130-bdac-3a26107f77fe

