### PR TITLE
fix(framework): date-range-picker portal be optional

### DIFF
--- a/framework/lib/components/date-picker/date-picker/date-range-picker.tsx
+++ b/framework/lib/components/date-picker/date-picker/date-range-picker.tsx
@@ -24,6 +24,19 @@ const parseValue = (value: any) => {
   return { start: parseDate(value.startDate), end: parseDate(value.endDate) }
 }
 
+const PortalWrapper = ({
+  renderInPortal,
+  children,
+}: {
+  renderInPortal: boolean
+  children: React.ReactNode
+}) => {
+  if (renderInPortal) {
+    return <Portal>{ children }</Portal>
+  }
+  return <>{ children }</>
+}
+
 /**
  * Popover to choose date range on format {startDate:' yyyy-mm-dd', endDate: 'yyyy-mm-dd'}
  *
@@ -85,6 +98,7 @@ export const DateRangePicker = (props: DateRangePickerProps) => {
     value,
     minValue = '1994-03-08',
     maxValue,
+    renderInPortal = false,
   } = props
   const ref = useRef() as React.MutableRefObject<HTMLInputElement>
   const { group } = useMultiStyleConfig('DatePicker')
@@ -170,22 +184,22 @@ export const DateRangePicker = (props: DateRangePickerProps) => {
           />
         </HStack>
       </PopoverAnchor>
-      <Portal>
+      <PortalWrapper renderInPortal={ renderInPortal }>
         { state.isOpen && (
-        <PopoverContent { ...dialogProps } ref={ ref } w="max-content">
-          <FocusScope contain={ true } restoreFocus={ true }>
-            <RangeCalendar
-              { ...calendarProps }
-              resetDate={ resetDate }
-              handleClose={ handleClose }
-              fiscalStartMonth={ fiscalStartMonth || 0 }
-              fiscalStartDay={ fiscalStartDay || 0 }
-              isClearable={ isClearable }
-            />
-          </FocusScope>
-        </PopoverContent>
+          <PopoverContent { ...dialogProps } ref={ ref } w="max-content">
+            <FocusScope contain={ true } restoreFocus={ true }>
+              <RangeCalendar
+                { ...calendarProps }
+                resetDate={ resetDate }
+                handleClose={ handleClose }
+                fiscalStartMonth={ fiscalStartMonth || 0 }
+                fiscalStartDay={ fiscalStartDay || 0 }
+                isClearable={ isClearable }
+              />
+            </FocusScope>
+          </PopoverContent>
         ) }
-      </Portal>
+      </PortalWrapper>
     </Popover>
   )
 }

--- a/framework/lib/components/date-picker/types.ts
+++ b/framework/lib/components/date-picker/types.ts
@@ -40,6 +40,7 @@ export interface DateRangePickerProps
   maxValue?: string | undefined
   fiscalStartMonth?: number
   fiscalStartDay?: number
+  renderInPortal?: boolean
 }
 
 export interface DatePickerFieldProps


### PR DESCRIPTION
Rendering the DateRangePicker in portal by default can cause problems with useOutsideClick, therefore this should be optional.

With Portal:
![7C487684-1A8C-447D-B812-161E02E359F6](https://github.com/mediatool/northlight/assets/90923099/49f75829-d5e2-43db-91c8-54ec2a625340)

Without Portal:
![DFBAC63E-E4F6-4CD8-8BC4-0CAC6A8DE74B](https://github.com/mediatool/northlight/assets/90923099/5f6d1c98-d3e8-4f93-b264-f4289b71cfd5)


