### PR TITLE
fix(framework): createableselectdropdown has new add new field option

### DIFF
--- a/framework/lib/components/createable-select-dropdown/custom-components.tsx
+++ b/framework/lib/components/createable-select-dropdown/custom-components.tsx
@@ -4,20 +4,33 @@ import { PlusSolid } from '@northlight/icons'
 import { Icon } from '../icon'
 import { Box } from '../box'
 import { Flex } from '../flex'
+import { Text } from '../text'
+
+const { Option: ChakraOption } = chakraComponents
 
 export const customComponents = {
   Option: ({ children, ...props }: any) => (
-    <chakraComponents.Option { ...props }>
-      <>
-        { props.data.isCreation ? (
-          <Flex mr={ 3 } width={ 1.5 } mb={ 0.5 } justifyContent="center" alignItems="center">
-            <Icon mb="4px" as={ PlusSolid } color="brand" />
-          </Flex>
-        ) : (
-          <Box mr={ 3 } width={ 1.5 } />
-        ) }
+    <ChakraOption { ...props }>
+      { props.data.isCreation && (
+      <Flex
+        mr={ 3 }
+        width={ 1.5 }
+        mb={ 0.5 }
+        justifyContent="center"
+        alignItems="center"
+      >
+        <Icon as={ PlusSolid } color="brand" />
+      </Flex>
+      ) }
+      { !props.data.isCreation && (
+      <Box mr={ 3 } width={ 1.5 } />
+      ) }
+      <Text
+        color={ props.data.isCreation ? 'text.brand' : 'text.default' }
+        fontWeight={ props.data.isCreation ? 'semibold' : 'normal' }
+      >
         { children }
-      </>
-    </chakraComponents.Option>
+      </Text>
+    </ChakraOption>
   ),
 }

--- a/framework/lib/components/editable-text/editable-controls.tsx
+++ b/framework/lib/components/editable-text/editable-controls.tsx
@@ -9,8 +9,21 @@ import {
 import { IconButton } from '../icon-button'
 import { Icon } from '../icon'
 import { EditableControlsProps } from './types'
+import { ButtonVariants } from '../button/types'
 
-export const EditableControls = ({ size }: EditableControlsProps) => {
+type MapVariantTypes = Record<EditableControlsProps['variant'], ButtonVariants>
+
+const mapEditableVariantsToButtonSubmitVariants: MapVariantTypes = {
+  brand: 'brand',
+  default: 'success',
+}
+
+const mapEditableVariantsToButtonCancelVariants: MapVariantTypes = {
+  brand: 'ghost',
+  default: 'danger',
+}
+
+export const EditableControls = ({ size, variant = 'default' }: EditableControlsProps) => {
   const {
     getSubmitButtonProps,
     getCancelButtonProps,
@@ -28,7 +41,7 @@ export const EditableControls = ({ size }: EditableControlsProps) => {
             <IconButton
               aria-label="Cancel"
               sx={ button }
-              variant="danger"
+              variant={ mapEditableVariantsToButtonCancelVariants[variant] }
               { ...getCancelButtonProps() }
             >
               <Icon sx={ icon } as={ XCloseSolid } />
@@ -36,7 +49,7 @@ export const EditableControls = ({ size }: EditableControlsProps) => {
             <IconButton
               aria-label="Save"
               sx={ button }
-              variant="success"
+              variant={ mapEditableVariantsToButtonSubmitVariants[variant] }
               { ...getSubmitButtonProps() }
             >
               <Icon sx={ icon } as={ CheckDuo } />

--- a/framework/lib/components/editable-text/editable-text.tsx
+++ b/framework/lib/components/editable-text/editable-text.tsx
@@ -40,6 +40,7 @@ export const EditableText = ({
   value: inputValue,
   onSubmit,
   leftItem,
+  variant = 'default',
   ...rest
 }: EditableProps) => {
   const [ value, setValue ] = useState(inputValue)
@@ -74,7 +75,7 @@ export const EditableText = ({
           sx={ input }
         />
         <InputRightElement sx={ { width: 'min-content' } }>
-          <EditableControls size={ size } />
+          <EditableControls size={ size } variant={ variant } />
         </InputRightElement>
       </InputGroup>
     </Editable>

--- a/framework/lib/components/editable-text/types.ts
+++ b/framework/lib/components/editable-text/types.ts
@@ -3,11 +3,15 @@ import { EditableProps as ChakraEditableProps } from '@chakra-ui/react'
 
 export type EditableSizes = 'sm' | 'md' | 'lg'
 
+export type EditableVariant = 'brand' | 'default'
+
 export interface EditableProps extends ChakraEditableProps {
   value?: string
   size?: EditableSizes
   leftItem? : ReactElement
+  variant?: EditableVariant
 }
 export interface EditableControlsProps {
   size: EditableSizes
+  variant: EditableVariant
 }

--- a/framework/lib/components/select/types.ts
+++ b/framework/lib/components/select/types.ts
@@ -18,6 +18,7 @@ type Size = 'sm' | 'md' | 'lg'
 export interface Option<T extends string = string> {
   label: string
   value: T
+  isCreation?: boolean
 }
 
 export interface SelectProps<T, K extends boolean>

--- a/framework/lib/general.d.ts
+++ b/framework/lib/general.d.ts
@@ -16,6 +16,7 @@ declare module 'react-select/dist/declarations/src/Select' {
     customTag?: CustomElementType<Option>
     icon?: ComponentType<any>
     leftComponent?: React.ReactNode
+    toggleCreateNewOption?: () => void
   }
 }
 


### PR DESCRIPTION
The CreatableSelectDropdown component has been updated to improve its functionality. When a user selects to "Add Field," the element now transitions from an Option to EditableText, streamlining the user experience. This enhancement allows for a more seamless process in adding fields, complete with appropriate 'Submit' and 'Cancel' buttons. Additionally, a new variant has been introduced, enabling color customization of the component.

closes: DEV-12420