### PR TITLE
fix(framework): fix wrong week numbers in date range picker

### DIFF
--- a/framework/lib/components/date-picker/components/calendar/components/get-week-number-start-of-month.ts
+++ b/framework/lib/components/date-picker/components/calendar/components/get-week-number-start-of-month.ts
@@ -29,7 +29,7 @@ export const getWeekNumberAtStartOfMonth = (
 
   const totalDaysUntilMonth = daysInMonths
     .slice(1, month)
-    .reduce(add, 0)
+    .reduce(add, 1)
 
   const weekNumber = Math.ceil(totalDaysUntilMonth / 7)
 


### PR DESCRIPTION
Just had to add +1 to the totalDaysUntilMonth counter to take into account the first day of a month

closed DEV-12024