### PR TITLE
fix(northlight): default button style update

### DIFF
--- a/framework/lib/theme/components/button/index.ts
+++ b/framework/lib/theme/components/button/index.ts
@@ -39,6 +39,7 @@ export const Button: ComponentSingleStyleConfig = {
   variants: {
     default: ({ theme: { colors: color } }) => ({
       bgColor: color.background.button.default,
+      color: color.text.button.default,
       _hover: {
         bgColor: color.background.button['default-hover'],
       },


### PR DESCRIPTION
Fixed the default button still having the black text, now updated with the brand one.

closes: DEV-12922

**Before:**
<img width="262" alt="Screenshot 2024-04-16 at 10 04 54" src="https://github.com/mediatool/northlight/assets/5406237/76ee7dbc-448d-4bb9-b3bb-76587b8e1726">

**After:**
<img width="255" alt="Screenshot 2024-04-16 at 10 04 39" src="https://github.com/mediatool/northlight/assets/5406237/b29d362d-90ae-4e98-bee6-2ecd8ccc6b93">


**Dark mode** (still the same):
<img width="226" alt="Screenshot 2024-04-16 at 10 06 19" src="https://github.com/mediatool/northlight/assets/5406237/bf3648d5-d6b3-4426-8ee1-3c6ca2c6cba0">

