### PR TITLE
fix(norhtlight): tabs docs and styling update

### DIFF
--- a/framework/lib/components/tabs/tabs.tsx
+++ b/framework/lib/components/tabs/tabs.tsx
@@ -3,18 +3,45 @@ import { Tabs as ChakraTabs } from '@chakra-ui/react'
 import { TabsProps } from './types'
 
 /**
- * Context provider for tabs tabs
+ * Tabs are used for secondary navigation between groups on the page of the same context.
  * @see TabList
  * @see TabPanels
  * @see {@link https://northlight.dev/reference/tabs}
  * @example
+ * ## Structure
+ * <br />
+ * - **Tabs**: Context provider and state manager for tab components.
+ * - **TabList**: Container for Tab items.
+ * - **Tab**: Interactive label for displaying a TabPanel.
+ * - **TabPanels**: Group wrapper for TabPanel items.
+ * - **TabPanel**: Content area for a Tab.
+ * <br />
+ * <br />
+ * You can render any element within `Tabs`, but `TabList` should only have `Tab` as children,
+ * and `TabPanels` should have `TabPanel` as children. <br />
+ * <br />
+ * `Tabs` expects `TabList` and `TabPanels` as children. The order doesn't matter,
+ * you can have `TabList` at the top, at the bottom, or both.
+ * <br />
+ * <br />
+ *
+ *  ## Usage
+ * <br />
+ * **Tabs** have three main variatns:
+ * `rounded` (default) or no variant, `soft-rounded` and `line`. <br />
+ * Also there are multiple sub-variants: `ai`, `enclosed`, `enclosed-colored` and `unstyled`
+ * <br />
+ * <br />
+ * tip: `enclosed` and `enclosed-colored` can be combined with the `colorScheme=""` prop.
+ * <br />
+ * <br />
  * (?
     <Tabs>
     <Stack spacing="2">
       <TabList>
-        <Tab>One</Tab>
-        <Tab>Two</Tab>
-        <Tab>Three</Tab>
+        <Tab><Icon as={ MediatoolLogoDuo } mr="2" />One</Tab>
+        <Tab><Icon as={ MediatoolLogoDuo } mr="2" />Two</Tab>
+        <Tab><Icon as={ MediatoolLogoDuo } mr="2" />Three</Tab>
       </TabList>
       <TabPanels>
         <TabPanel>
@@ -34,7 +61,7 @@ import { TabsProps } from './types'
  */
 export const Tabs = (({
   children,
-  variant = 'soft-rounded',
+  variant = 'rounded',
   isManual = true,
   ...rest
 }: TabsProps) => (

--- a/framework/lib/theme/components/tabs/index.ts
+++ b/framework/lib/theme/components/tabs/index.ts
@@ -2,6 +2,11 @@ import { ComponentMultiStyleConfig } from '@chakra-ui/react'
 
 export const Tabs: ComponentMultiStyleConfig = {
   parts: [ 'tab' ],
+  baseStyle: ({ theme: { fontWeights: coreFontWeight } }) => ({
+    tab: {
+      fontWeight: coreFontWeight.semiBold,
+    },
+  }),
   variants: {
     'soft-rounded': ({ theme: { colors: color } }) => ({
       tab: {
@@ -9,6 +14,27 @@ export const Tabs: ComponentMultiStyleConfig = {
         color: color.text.subdued,
         _selected: {
           bg: color.background.tabs['soft-rounded-active'],
+          color: color.text.tabs['soft-rounded-active'],
+        },
+        _hover: {
+          color: color.text.tabs['soft-rounded-active'],
+        },
+        _focusVisible: {
+          ring: '2px',
+          ringColor: color.border.wcag,
+          ringOffset: '1px',
+        },
+      },
+    }),
+    rounded: ({ theme: { colors: color, radii: borderRadius } }) => ({
+      tab: {
+        color: color.text.subdued,
+        borderRadius: borderRadius.button.default,
+        _selected: {
+          bg: color.background.tabs['soft-rounded-active'],
+          color: color.text.tabs['soft-rounded-active'],
+        },
+        _hover: {
           color: color.text.tabs['soft-rounded-active'],
         },
         _focusVisible: {
@@ -24,6 +50,25 @@ export const Tabs: ComponentMultiStyleConfig = {
         _selected: {
           bgColor: color.bg.ai.default,
           color: color.text.inverted,
+        },
+        _focusVisible: {
+          ring: '2px',
+          ringColor: color.border.wcag,
+          ringOffset: '1px',
+        },
+      },
+    }),
+    line: ({ theme: { colors: color } }) => ({
+      tab: {
+        color: color.text.subdued,
+        _selected: {
+          color: color.text.tabs['soft-rounded-active'],
+        },
+        _hover: {
+          color: color.text.tabs['soft-rounded-active'],
+        },
+        _active: {
+          bg: color.mono.transparent,
         },
         _focusVisible: {
           ring: '2px',


### PR DESCRIPTION
Updated the tabs docs.
Updated the style for the variants: `soft-rounded` and `line`, and added one more variant - `rounded`


Intro:
https://github.com/mediatool/northlight/assets/5406237/943f4927-aac9-4a2d-b4b9-d34d6e6f6288


Dark mode check:
<img width="415" alt="Screenshot 2024-04-16 at 15 47 51" src="https://github.com/mediatool/northlight/assets/5406237/9a9a8599-6dda-4104-bd20-b635682d9a22">
<img width="362" alt="Screenshot 2024-04-16 at 15 47 41" src="https://github.com/mediatool/northlight/assets/5406237/27c86e03-66fd-4233-a9bb-fcc6f2adc990">
<img width="405" alt="Screenshot 2024-04-16 at 15 47 31" src="https://github.com/mediatool/northlight/assets/5406237/ef3c2531-ba34-404c-be31-04d6b89b875f">


closes: DEV-12918