### PR TITLE
fix(framework): avatar group allow negative spacing

### DIFF
--- a/framework/lib/components/avatar/avatar-group.tsx
+++ b/framework/lib/components/avatar/avatar-group.tsx
@@ -3,6 +3,7 @@ import { HStack } from '../stack'
 import { AvatarGroupProps } from './types'
 import { Small } from '../typography'
 import { OverflowGroup } from '../overflow-group'
+import { getChildrenWithProps } from '../../utils'
 
 /**
  * Used to display a group of users
@@ -32,12 +33,17 @@ export const AvatarGroup = ({
   ...rest
 }: AvatarGroupProps) => {
   const [ nbrRemainingAvatars, setNbrRemainingAvatars ] = useState(0)
+  const childrenWithMargin = getChildrenWithProps(
+    children,
+    { ml: spacing },
+    (_child, idx) => idx > 0
+  )
 
   return (
     <HStack bgColor="background.default" { ...rest }>
-      <HStack spacing={ spacing }>
+      <HStack spacing={ 0 }>
         <OverflowGroup max={ max } onChange={ setNbrRemainingAvatars }>
-          { children }
+          { childrenWithMargin }
         </OverflowGroup>
       </HStack>
       { nbrRemainingAvatars > 0 && (


### PR DESCRIPTION
In Chakra UI v.2.7.0
(https://github.com/chakra-ui/chakra-ui/releases/tag/%40chakra-ui%2Freact%402.7.0) the implementation of the <Stack> components were changed to use flex gap instead of putting margin on the children. This removed the the functionality to put negative spacing.

This should still be available however in AvatarGroup, so marginLeft has been added to children manually to maintain previous behvaiour

closed: DEV-14033

https://github.com/mediatool/northlight/assets/90923099/a03f81ec-5a06-4e2c-9f67-24f190a54f28


