### PR TITLE
fix(framework): add cursor pointer to select component

### DIFF
--- a/framework/lib/components/select/select.tsx
+++ b/framework/lib/components/select/select.tsx
@@ -180,7 +180,7 @@ export const Select = forwardRef(<T extends Option, K extends boolean = false>({
   }, [ options ])
 
   return (
-    <Box w="full" data-testid={ testId }>
+    <Box w="full" data-testid={ testId } cursor="pointer">
       <ChakraReactSelect
         isMulti={ isMulti }
         options={ renderedOptions }


### PR DESCRIPTION
There is currently no indication that the select is clickable apart form the caret. This commit adds a cursor pointer to the box element containing the select to clearly show that it is clickable.

DEV-14454