### PR TITLE
feat(northligh-ui): allow search bar default values as boolean

### DIFF
--- a/framework/lib/components/search-bar/search-bar.tsx
+++ b/framework/lib/components/search-bar/search-bar.tsx
@@ -55,19 +55,24 @@ export const SearchBar = forwardRef(
       []
     )
 
-    const simpleFilter = (query: string) => (
-      filter(
+    const simpleFilter = (query: string) => {
+      if (typeof defaultOptions === 'boolean') return []
+      return filter(
         (option: T) =>
           test(new RegExp(toLower(query), 'g'), toLower(option.label)),
         defaultOptions
       )
-    )
-
+    }
     const getOptions = async (query: string) => {
       const newOptions = getCustomOptions
         ? await getCustomOptions(query)
         : simpleFilter(query)
-      setFiltered(newOptions)
+      setFiltered((prev) => {
+        // If default value is a boolean we want default value to persist to it's initial value
+        // this is to allow pre-fetching of values on first render
+        if (typeof prev === 'boolean') return prev
+        return newOptions
+      })
 
       return newOptions
     }

--- a/framework/lib/components/search-bar/types.ts
+++ b/framework/lib/components/search-bar/types.ts
@@ -33,7 +33,7 @@ export interface SearchBarProps<T extends SearchBarOptionType, K extends boolean
   debouncedWaitTime?: number
   clearInputOnSelect?: boolean
   closeMenuonSelect?: boolean
-  defaultOptions?: T[]
+  defaultOptions?: T[] | boolean
   sx?: ChakraStylesConfig<any>
   isMulti?: K
   customOption?: CustomElementType<T>


### PR DESCRIPTION
added support for passing boolean as default value to search bar. passing defaultValue true will make sure that load options will be called on first render of component.