### PR TITLE
fix(northlight-ui): fix firstdayofweek in calendar

### DIFF
--- a/framework/lib/components/date-picker/date-picker/date-picker-locale-wrapper.tsx
+++ b/framework/lib/components/date-picker/date-picker/date-picker-locale-wrapper.tsx
@@ -1,0 +1,16 @@
+import React, { ReactNode } from 'react'
+import { I18nProvider } from '@react-aria/i18n'
+import { FirstDayOfWeek } from '../components/calendar/components/types'
+
+interface DatePickerLocaleWrapperProps {
+  firstDayOfWeek: FirstDayOfWeek
+  children: ReactNode
+}
+
+export const DatePickerLocaleWrapper = ({
+  firstDayOfWeek,
+  children,
+}: DatePickerLocaleWrapperProps) => {
+  const locale = firstDayOfWeek === 'monday' ? 'en-DE' : 'en-US'
+  return <I18nProvider locale={ locale }>{ children }</I18nProvider>
+}

--- a/framework/lib/components/date-picker/date-picker/date-picker.tsx
+++ b/framework/lib/components/date-picker/date-picker/date-picker.tsx
@@ -14,6 +14,7 @@ import { InputGroup, InputRightElement } from '../../input'
 import { Popover, PopoverAnchor, PopoverContent } from '../../popover'
 import { Icon } from '../../icon'
 import { Box } from '../../box'
+import { DatePickerLocaleWrapper } from './date-picker-locale-wrapper'
 
 /**
  * Popover to select single date
@@ -133,7 +134,9 @@ export const DatePicker = (props: DatePickerProps) => {
       { state.isOpen && (
         <PopoverContent { ...dialogProps } ref={ ref } w={ 64 } border="none">
           <FocusScope contain={ true } restoreFocus={ true }>
-            <Calendar { ...calendarProps } firstDayOfWeek={ firstDayOfWeek } />
+            <DatePickerLocaleWrapper firstDayOfWeek={ firstDayOfWeek }>
+              <Calendar { ...calendarProps } firstDayOfWeek={ firstDayOfWeek } />
+            </DatePickerLocaleWrapper>
           </FocusScope>
         </PopoverContent>
       ) }

--- a/framework/lib/components/date-picker/date-picker/date-range-picker.tsx
+++ b/framework/lib/components/date-picker/date-picker/date-range-picker.tsx
@@ -18,6 +18,7 @@ import { IconButton } from '../../icon-button'
 import { InputGroup, InputRightElement } from '../../input'
 import { Icon } from '../../icon'
 import { isValidDateRange } from '../date-picker-field/utils'
+import { DatePickerLocaleWrapper } from './date-picker-locale-wrapper'
 
 const parseValue = (value: any) => {
   if (!isValidDateRange(value)) return null
@@ -114,7 +115,6 @@ export const DateRangePicker = (props: DateRangePickerProps) => {
     minValue: isNil(minValue) ? undefined : (parseDate(minValue) as DateValue),
     maxValue: isNil(maxValue) ? undefined : (parseDate(maxValue) as DateValue),
   }
-
   const state = useDateRangePickerState({
     ...props,
     ...parsedProps,
@@ -194,15 +194,17 @@ export const DateRangePicker = (props: DateRangePickerProps) => {
         { state.isOpen && (
           <PopoverContent { ...dialogProps } ref={ ref } w="max-content">
             <FocusScope contain={ true } restoreFocus={ true }>
-              <RangeCalendar
-                { ...calendarProps }
-                resetDate={ resetDate }
-                handleClose={ handleClose }
-                fiscalStartMonth={ fiscalStartMonth || 0 }
-                fiscalStartDay={ fiscalStartDay || 0 }
-                isClearable={ isClearable }
-                firstDayOfWeek={ firstDayOfWeek }
-              />
+              <DatePickerLocaleWrapper firstDayOfWeek={ firstDayOfWeek }>
+                <RangeCalendar
+                  { ...calendarProps }
+                  resetDate={ resetDate }
+                  handleClose={ handleClose }
+                  fiscalStartMonth={ fiscalStartMonth || 0 }
+                  fiscalStartDay={ fiscalStartDay || 0 }
+                  isClearable={ isClearable }
+                  firstDayOfWeek={ firstDayOfWeek }
+                />
+              </DatePickerLocaleWrapper>
             </FocusScope>
           </PopoverContent>
         ) }

--- a/framework/lib/components/date-picker/date-picker/index.ts
+++ b/framework/lib/components/date-picker/date-picker/index.ts
@@ -1,2 +1,3 @@
 export * from './date-picker'
 export * from './date-range-picker'
+export * from './date-picker-locale-wrapper'


### PR DESCRIPTION
This commit resolves the issue where the labels and dates did not correspond correctly in the grid. The underlying issue was that the imported library component does not currently support switching the first day of the week directly; this setting is controlled via the locale.

To address this issue, the component is now wrapped with a provider that sets the locale based on the user's selected setting. This ensures that the labels align correctly with their respective dates. 

closes: #DEV-14275