### PR TITLE
chore(norhtlight): badge sizes improvement

### DIFF
--- a/framework/lib/components/badge/badge.tsx
+++ b/framework/lib/components/badge/badge.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef } from 'react'
-import { BadgeProps, Badge as ChakraBadge } from '@chakra-ui/react'
+import { Badge as ChakraBadge } from '@chakra-ui/react'
+import { BadgeProps } from './types'
 
 /**
  * Badges are used to highlight an item's status for quick recognition.

--- a/framework/lib/components/badge/types.ts
+++ b/framework/lib/components/badge/types.ts
@@ -1,0 +1,11 @@
+import { BadgeProps as ChakraBadgeProps, ThemingProps } from '@chakra-ui/react'
+
+type BadgeSize = 'xs' | 'sm' | 'md' | 'lg'
+type BadgeVariant = 'solid' | 'outline' | 'subtle'
+type ColorScheme = ThemingProps['colorScheme']
+
+export interface BadgeProps extends Omit<ChakraBadgeProps, 'size' | 'variant' > {
+  size?: BadgeSize
+  variant?: BadgeVariant
+  colorScheme?: ColorScheme
+}

--- a/framework/lib/theme/components/badge/index.ts
+++ b/framework/lib/theme/components/badge/index.ts
@@ -37,4 +37,21 @@ export const Badge: ComponentSingleStyleConfig = {
       }
     },
   },
+  sizes: {
+    xs: {
+      fontSize: '2xs',
+    },
+    sm: {
+      fontSize: 'xs',
+    },
+    md: {
+      fontSize: 'sm',
+    },
+    lg: {
+      fontSize: 'md',
+    },
+  },
+  defaultProps: {
+    size: 'sm',
+  },
 }


### PR DESCRIPTION
Description
This PR enhances the Badge component by introducing size variants and ensuring that the colorScheme property is correctly typed. The key changes include:

1. **Size Variants:** Added support for sm, md, and lg sizes, allowing more flexibility in the badge's appearance.
2. **ColorScheme Typing:** Utilized the ColorScheme type from @chakra-ui/react to ensure type safety and autocompletion for the colorScheme property.
3. **TypeScript Definitions**: Updated the BadgeProps interface to include the new size and variant properties while extending from ChakraBadgeProps.

These improvements enhance the flexibility and robustness of the Badge component, making it easier to use and maintain.

Changes
1. Updated Badge component to support **2xs,** **xs**(default one that we use right now across the app), **sm** and **md** sizes.
2. Ensured colorScheme property uses ColorSchemes 1:1 from Figma's sketches for the Badge.
3. Extended BadgeProps interface for better type safety and developer experience.

![Screenshot 2024-07-11 at 16 42 15](https://github.com/mediatool/northlight/assets/5406237/ed1537c2-18f3-4cc8-8d72-b112db4cb44b)

