### PR TITLE
chore(northlight): Add semantic colors and cons padding to StatusPin

### DIFF
--- a/framework/lib/components/status-pin/pin-size-map.ts
+++ b/framework/lib/components/status-pin/pin-size-map.ts
@@ -3,5 +3,5 @@ import { PinSize, PinSizeTuple } from '../pin-input/types'
 export const pinSizeMap: Record<PinSize, PinSizeTuple > = {
   sm: [ 4, 2 ],
   md: [ 5, 3 ],
-  lg: [ 6, 3.5 ],
+  lg: [ 6, 4 ],
 }

--- a/framework/lib/components/status-pin/pin-variant-map.ts
+++ b/framework/lib/components/status-pin/pin-variant-map.ts
@@ -1,13 +1,12 @@
-import { Color, ColorGrade } from '../../types'
 import { PinVariant } from '../pin-input/types'
 
-export const pinVariantMap: Record<PinVariant, `${Color}.${ColorGrade}`> = {
-  green: 'green.500',
-  running: 'green.500',
-  yellow: 'yellow.600',
-  inProgress: 'yellow.600',
-  gray: 'gray.300',
-  notExecuted: 'gray.300',
-  red: 'red.500',
-  rejected: 'red.500',
+export const pinVariantMap: Record<PinVariant, string> = {
+  green: 'success',
+  running: 'success',
+  yellow: 'info',
+  inProgress: 'info',
+  gray: 'subdued',
+  notExecuted: 'subdued',
+  red: 'destructive',
+  rejected: 'destructive',
 }

--- a/framework/lib/components/status-pin/status-pin.tsx
+++ b/framework/lib/components/status-pin/status-pin.tsx
@@ -5,30 +5,35 @@ import { pinSizeMap } from './pin-size-map'
 import { StatusPinProps } from './types'
 
 /**
+ * Status pins are meant to display the status of a specific entry.
+ * @see Badge
  * @see {@link https://northlight/reference/status-pin}
  *
- * @example
+ * @example (Example)
  * (?
  * +
- * const variants = ["running", "inProgress", "notExecuted", "rejected"]
- * const sizes = ["sm", "md", "lg"]
+ * const sizes = ['lg', 'md', 'sm']
+ * const variants = ['notExecuted', 'running', 'inProgress', 'rejected']
+ *
  * const Example = () => {
- *     return <Stack>
- *         { sizes.map((size) => (
- *         <HStack spacing={ 4 }>
- *             {
- *                 variants.map((variant) => (
- *                 <StatusPin variant={variant} size={size} />
- *                 ))
- *             }
- *             </HStack>
- *         ))}
- *         </Stack>
+ *    return (
+ *      <Stack>
+ *        {variants.map((variant)=>(
+ *          <HStack spacing={4} alignItems="center">
+ *            {sizes.map((size)=>(
+ *              <StatusPin size={size} variant={variant} />
+ *            ))}
+ *          </HStack>
+ *        ))}
+ *      </Stack>
+ *    )
  * }
  * render(<Example/>)
  * ?)
  *
  */
+
+
 export const StatusPin = ({ size = 'md', variant, ...rest }: StatusPinProps) => {
   const pinColor = pinVariantMap[variant]
   const pinSizeTuple = pinSizeMap[size]
@@ -37,8 +42,8 @@ export const StatusPin = ({ size = 'md', variant, ...rest }: StatusPinProps) => 
   return (
     <Circle
       size={ outerSize }
-      bg="white"
-      borderWidth="1px"
+      bg="transparent"
+      borderWidth="xs"
       borderColor={ pinColor }
       { ...rest }
     >


### PR DESCRIPTION
Updated innerPin size for lg to be 4 instead of 3.5 to improve consistency of padding and scaling between size variants. Adjusted colorVariant mapping to use semantic tokens instead of green.500 etc and set bg to transparent. 
Updated documentation by adding more details, linking to related badge component and improving the usage presentation.

Closes: DEV-14603