### PR TITLE
feat(northlight-ui): add next week to date range picker

### DIFF
--- a/framework/lib/components/date-picker/components/calendar/quick-navigation/get-quick-select-options.ts
+++ b/framework/lib/components/date-picker/components/calendar/quick-navigation/get-quick-select-options.ts
@@ -42,6 +42,14 @@ export const getQuickSelectOptions = (
     label: 'This Week',
   }
 
+  const nextWeek = {
+    value: {
+      start: startOfWeek(thisDay.add({ weeks: 1 }), locale),
+      end: endOfWeek(thisDay.add({ weeks: 1 }), locale),
+    },
+    label: 'Next Week',
+  }
+
   const lastWeek = {
     value: {
       start: startOfWeek(thisDay.subtract({ weeks: 1 }), locale),
@@ -250,17 +258,18 @@ export const getQuickSelectOptions = (
     fiscalStartMonth === 0 ? [] : [ thisFiscalYear, lastFiscalYear ]
 
   const quickDates = [
-    thisWeek,
-    lastWeek,
-    thisMonth,
-    lastMonth,
-    thisYear,
     yearToDate,
-    lastYear,
-    nextMonth,
+    lastWeek,
+    nextWeek,
+    thisWeek,
+    lastMonth,
     nextThreeMonths,
     nextSixMonths,
+    nextMonth,
+    thisMonth,
+    lastYear,
     nextYear,
+    thisYear,
     ...fiscalYears,
   ]
 


### PR DESCRIPTION
This commit resolves the issue where we wanted to add Next Week as an option in the date range picker. Previously, we had This Week and Last Week, but users can now also select Next Week. 

https://github.com/user-attachments/assets/4ee6ecce-1280-480a-87c5-3a4dd24ae654

closes: #DEV-13744