### PR TITLE
chore(northlight): new badge variant

### DIFF
--- a/framework/lib/components/badge/badge.tsx
+++ b/framework/lib/components/badge/badge.tsx
@@ -11,7 +11,7 @@ import { BadgeProps } from './types'
  * +
  * const colors = ["gray", "mediatoolBlue", "blue", "red", "green",
  * "orange", "yellow", "teal", "purple", "pink"]
- * const variants = ["solid", "outline", "subtle"]
+ * const variants = ["solid", "outline", "subtle", "ghost"]
  * const Example = () => {
  *     return <Stack>
  *         { colors.map((color) => (

--- a/framework/lib/components/badge/types.ts
+++ b/framework/lib/components/badge/types.ts
@@ -1,7 +1,7 @@
 import { BadgeProps as ChakraBadgeProps, ThemingProps } from '@chakra-ui/react'
 
 type BadgeSize = 'xs' | 'sm' | 'md' | 'lg'
-type BadgeVariant = 'solid' | 'outline' | 'subtle'
+type BadgeVariant = 'solid' | 'outline' | 'subtle' | 'ghost'
 type ColorScheme = ThemingProps['colorScheme']
 
 export interface BadgeProps extends Omit<ChakraBadgeProps, 'size' | 'variant' > {

--- a/framework/lib/theme/components/badge/index.ts
+++ b/framework/lib/theme/components/badge/index.ts
@@ -36,6 +36,16 @@ export const Badge: ComponentSingleStyleConfig = {
         color: textColor,
       }
     },
+    ghost: ({ colorScheme, theme: { colors } }) => {
+      const textColor = colorScheme === 'mediatoolBlue'
+        ? colors[colorScheme][500]
+        : colors[colorScheme] && colors[colorScheme][700]
+
+      return {
+        bgColor: 'mono.transparent',
+        color: textColor,
+      }
+    },
   },
   sizes: {
     xs: {


### PR DESCRIPTION
Introducing new badge **_Ghost_** variant.

Light theme:
<img width="243" alt="Screenshot 2024-07-24 at 08 50 53" src="https://github.com/user-attachments/assets/39f79b05-d25b-4a87-817e-d1b2e59cb550">

Dark theme:
<img width="215" alt="Screenshot 2024-07-24 at 08 50 59" src="https://github.com/user-attachments/assets/38f4862c-54ef-45b6-b417-d86fb35b3bbf">


closes: DEV-13999