### PR TITLE
chore(framework): enable override for toolbox body

### DIFF
--- a/framework/lib/components/toolbox/toolbox-content.tsx
+++ b/framework/lib/components/toolbox/toolbox-content.tsx
@@ -8,8 +8,8 @@ import { ToolboxContentProps } from './types'
  * @see Toolbox
  * @see {@link https://northlight.dev/reference/toolbox-content}
  */
-export const ToolboxContent = ({ children, ...rest }: ToolboxContentProps) => {
-  const { body } = useMultiStyleConfig('Toolbox', {})
+export const ToolboxContent = ({ sx = {}, children, ...rest }: ToolboxContentProps) => {
+  const { body } = useMultiStyleConfig('Toolbox', { sx })
 
   return (
     <Flex

--- a/framework/lib/theme/components/toolbox/index.ts
+++ b/framework/lib/theme/components/toolbox/index.ts
@@ -1,8 +1,9 @@
 import { ComponentMultiStyleConfig } from '@chakra-ui/react'
+import { merge } from 'ramda'
 
 export const Toolbox: ComponentMultiStyleConfig = {
   parts: [ 'container', 'header', 'body', 'footer' ],
-  baseStyle: ({ theme: { sizes: sizing } }) => ({
+  baseStyle: ({ sx, theme: { sizes: sizing } }) => ({
     container: {
       position: 'relative',
       bg: 'text.inverted',
@@ -31,14 +32,14 @@ export const Toolbox: ComponentMultiStyleConfig = {
       borderTopStyle: 'solid',
       borderTopColor: 'gray.100',
     },
-    body: {
+    body: merge({
       p: sizing['4'],
       flexDirection: 'column',
       w: '100%',
       h: '100%',
       maxH: `calc(100vh - ${sizing['16']} * 2)`,
       overflowY: 'scroll',
-    },
+    }, sx.body),
   }),
   sizes: {
     sm: {


### PR DESCRIPTION
We are accepting sx as an argument to the toolbox component in order to be able to override props in the body