### PR TITLE
chore(framework): add sx to toolbox content

### DIFF
--- a/framework/lib/components/toolbox/toolbox-content.tsx
+++ b/framework/lib/components/toolbox/toolbox-content.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { useMultiStyleConfig } from '@chakra-ui/system'
+import { merge } from 'ramda'
 import { Flex } from '../flex'
 import { ToolboxContentProps } from './types'
 
@@ -8,12 +9,12 @@ import { ToolboxContentProps } from './types'
  * @see Toolbox
  * @see {@link https://northlight.dev/reference/toolbox-content}
  */
-export const ToolboxContent = ({ children, ...rest }: ToolboxContentProps) => {
+export const ToolboxContent = ({ sx = {}, children, ...rest }: ToolboxContentProps) => {
   const { body } = useMultiStyleConfig('Toolbox', {})
 
   return (
     <Flex
-      sx={ body }
+      sx={ merge(body, sx) }
       { ...rest }
     >
       { children }

--- a/framework/lib/components/toolbox/toolbox.tsx
+++ b/framework/lib/components/toolbox/toolbox.tsx
@@ -10,6 +10,7 @@ import { Portal } from '../portal'
 import { ToolboxProps } from './types'
 import { getChildrenWithProps } from '../../utils'
 import { ResizeHandle } from '../resize-handle'
+import { VStack } from '../stack'
 
 /**
  * Controllable Sidebar drawer
@@ -117,9 +118,9 @@ export const Toolbox = ({
           >
             { isResizable && <ResizeHandle { ...resizeProps } /> }
             <FocusScope autoFocus={ autoFocus }>
-              <Box width="full" height="full">
+              <VStack width="full" height="full">
                 { newChildren }
-              </Box>
+              </VStack>
             </FocusScope>
           </Flex>
         </Slide>


### PR DESCRIPTION
Toolbox content accepts sx as prop in order to be able to override styling. Changed children wrapper in toolbox from box to vstack to be able to use flex grow for children