### PR TITLE
fix(northlight): tooltip style updates

### DIFF
--- a/framework/lib/components/tooltip/tooltip.tsx
+++ b/framework/lib/components/tooltip/tooltip.tsx
@@ -7,7 +7,7 @@ import {
 import { Label, P } from '../typography'
 import { Icon } from '../icon'
 import { AlertVariants } from '../alert'
-import { toastIconMap } from '../types/toastIconMap'
+import { tooltipIconMap } from '../types/tooltipIconMap'
 import { OurTooltipProps } from './types'
 
 /**
@@ -177,7 +177,7 @@ export const Tooltip: React.FC<OurTooltipProps> = ({
   ...rest
 }) => {
   const iconVariant: AlertVariants = variant as AlertVariants
-  const icon = toastIconMap[iconVariant]
+  const icon = tooltipIconMap[iconVariant]
 
   const TooltipContent = (
     <HStack alignItems="flex-start">

--- a/framework/lib/components/types/tooltipIconMap/index.ts
+++ b/framework/lib/components/types/tooltipIconMap/index.ts
@@ -1,0 +1,21 @@
+import {
+  AlertCircleSolid,
+  AlertOctagonSolid,
+  AlertTriangleSolid,
+  BrightnessSolid,
+  CheckCircleSolid,
+  HelpCircleSolid,
+  InfoSolid,
+} from '@northlight/icons'
+import { AlertVariants } from '../../alert/types'
+
+export const tooltipIconMap: Record<AlertVariants, any> = {
+  success: CheckCircleSolid,
+  warning: AlertTriangleSolid,
+  error: AlertCircleSolid,
+  danger: AlertOctagonSolid,
+  info: InfoSolid,
+  ai: BrightnessSolid,
+  default: HelpCircleSolid,
+  ghost: HelpCircleSolid,
+}

--- a/framework/lib/theme/components/tooltip/index.ts
+++ b/framework/lib/theme/components/tooltip/index.ts
@@ -54,6 +54,11 @@ export const Tooltip: ComponentSingleStyleConfig = {
       bgColor: color['destructive-alt'],
       [$arrowBg.variable]: color['destructive-alt'],
     }),
+    error: ({ theme: { colors: color } }) => ({
+      color: 'text.over.error',
+      bgColor: color['destructive-alt'],
+      [$arrowBg.variable]: color['destructive-alt'],
+    }),
     ai: ({ theme: { colors: color } }) => ({
       bgColor: color.bg.ai.default,
       [$arrowBg.variable]: color.bg.ai.default,


### PR DESCRIPTION
Couple of minor updates for the `tooltip`

1. Changed the `variant="info"` icon.

From:
<img width="351" alt="Screenshot 2024-10-18 at 11 39 48" src="https://github.com/user-attachments/assets/a741f892-098a-41e2-be12-44ccef73b920">

To:
<img width="360" alt="Screenshot 2024-10-18 at 11 39 00" src="https://github.com/user-attachments/assets/809fcb10-2cb6-4c09-a5ac-6329ec81accd">
<img width="380" alt="Screenshot 2024-10-18 at 11 38 55" src="https://github.com/user-attachments/assets/1c2e051c-c221-4497-bfb0-f91bd90d3cda">


Updated/Swaped the `variant="danger"` and `variant="error"` icons to match the purpose of the tooltip and define more straight to the point visual language:

For the `variant="danger"`

From:
<img width="154" alt="Screenshot 2024-10-18 at 11 53 45" src="https://github.com/user-attachments/assets/9988de41-a4c7-4934-a773-2a3086f38893">

To:
<img width="212" alt="Screenshot 2024-10-18 at 11 54 05" src="https://github.com/user-attachments/assets/93b67714-385b-4496-a0b8-32969127785b">


Added new types/mapping for the tooltip - `tooltipIconMap`


closes: DEV-16089