### PR TITLE
fix(framework): handle updates to components prop in select

### DIFF
--- a/framework/lib/components/select/select.tsx
+++ b/framework/lib/components/select/select.tsx
@@ -6,7 +6,7 @@ import {
   SelectInstance,
 } from 'chakra-react-select'
 import { Box } from '@chakra-ui/react'
-import { equals, identity, is } from 'ramda'
+import { always, equals, identity, is } from 'ramda'
 import { Option, SelectProps } from './types'
 import { customSelectStyles } from '../../theme/components/select/custom-select'
 import { useSelectCallbacks } from '../../hooks'
@@ -152,6 +152,7 @@ export const Select = forwardRef(<T extends Option, K extends boolean = false>({
   value,
   icon,
   components,
+  generateComponentsUpdateKey = always(0),
   ...rest
 }: SelectProps<T, K>,
   ref: Ref<SelectInstance<T, K, GroupBase<T>>>
@@ -166,7 +167,7 @@ export const Select = forwardRef(<T extends Option, K extends boolean = false>({
 
   const customComponents = useMemo(
     () => getComponents<T>(components),
-    []
+    [ generateComponentsUpdateKey() ]
   )
 
   const prevOptions = useRef<OptionsOrGroups<T, GroupBase<T>> | undefined>(

--- a/framework/lib/components/select/types.ts
+++ b/framework/lib/components/select/types.ts
@@ -49,6 +49,10 @@ export interface SelectProps<T, K extends boolean>
   customOption?: ((option: T) => JSX.Element) | null
   isMulti?: K
   ref?: Ref<SelectInstance<T, K, GroupBase<T>>>
+  /** Should return a unique key that is tracked so when the key changes
+      the sub-components for react-select will be recomputed/rerendered
+  */
+  generateComponentsUpdateKey?: () => unknown
 }
 
 export type SelectFieldProps<T, K extends boolean = false> = SelectProps<T, K> &


### PR DESCRIPTION
Previousely if the components prop definition changed those changes would not rerender. This was due to
useMemo hook only rendering on mount, an optional key function can now be supplied to rerender the sub-compoennts properly