### PR TITLE
fix(northlight-ui): fix weeks in date picker

### DIFF
--- a/framework/lib/components/date-picker/components/calendar/components/get-week-number-start-of-month.ts
+++ b/framework/lib/components/date-picker/components/calendar/components/get-week-number-start-of-month.ts
@@ -1,37 +1,68 @@
-import { add } from 'ramda'
+const MILLISECONDS_PER_DAY = 86400000
+
+const getThursdayDate = (date: Date): Date => {
+  const thursdayDate = new Date(date)
+  thursdayDate.setDate(date.getDate() + (4 - (date.getDay() || 7)))
+  return thursdayDate
+}
+
+const hasWeek53 = (year: number): boolean => {
+  const firstDayOfYear = new Date(year, 0, 1)
+  return firstDayOfYear.getDay() === 4 ||
+         (firstDayOfYear.getDay() === 3 && new Date(year, 1, 29).getMonth() === 1)
+}
 
 export const getWeekNumberAtStartOfMonth = (
   year: number,
-  month: number,
-  weekDay: number
+  month: number
 ): number => {
-  if (month === 1) {
-    return weekDay > 3 ? 52 : 1
+  const firstDayOfMonth = new Date(year, month - 1, 1)
+  const thursdayOfFirstWeek = getThursdayDate(firstDayOfMonth)
+  const firstDayOfYear = new Date(year, 0, 1)
+  const firstThursdayOfYear = getThursdayDate(firstDayOfYear)
+  const daysDifference = thursdayOfFirstWeek.getTime() - firstThursdayOfYear.getTime()
+  const weekNumber = Math.ceil((daysDifference / MILLISECONDS_PER_DAY + 1) / 7)
+
+  const isYearTransition = firstThursdayOfYear.getFullYear() < year
+  const isJanuaryTransition = isYearTransition
+  && thursdayOfFirstWeek.getFullYear() < year && month === 1
+
+  if (isJanuaryTransition) {
+    return hasWeek53(year - 1) ? 53 : 52
   }
 
-  const isLeapYear = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0
+  if (isYearTransition && month > 1) {
+    return weekNumber - 1
+  }
 
-  const daysInMonths = [
-    0,
-    31,
-    isLeapYear ? 29 : 28,
-    31,
-    30,
-    31,
-    30,
-    31,
-    31,
-    30,
-    31,
-    30,
-    31,
-  ]
-
-  const totalDaysUntilMonth = daysInMonths
-    .slice(1, month)
-    .reduce(add, 1)
-
-  const weekNumber = Math.ceil(totalDaysUntilMonth / 7)
+  if (month === 1 && weekNumber > 51) {
+    return !hasWeek53(year - 1) ? 1 : weekNumber
+  }
 
   return weekNumber
+}
+
+export const getDisplayWeek = (
+  baseWeek: number,
+  weekIndex: number,
+  year: number,
+  month: number
+): number => {
+  const isJanuaryEdgeCase = month === 1 && baseWeek > 51
+
+  if (isJanuaryEdgeCase) {
+    return weekIndex === 0 ? baseWeek : weekIndex
+  }
+
+  if (weekIndex === 0) {
+    return baseWeek
+  }
+
+  const nextWeek = baseWeek + weekIndex
+
+  if (nextWeek > 52) {
+    return hasWeek53(year) && nextWeek === 53 ? 53 : nextWeek - 52
+  }
+
+  return nextWeek
 }

--- a/framework/lib/components/date-picker/components/calendar/components/standalone-calendar-grid.tsx
+++ b/framework/lib/components/date-picker/components/calendar/components/standalone-calendar-grid.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react'
 import { chakra } from '@chakra-ui/react'
 import { useCalendar, useCalendarGrid } from '@react-aria/calendar'
-import { getDayOfWeek, getWeeksInMonth } from '@internationalized/date'
+import { getWeeksInMonth } from '@internationalized/date'
 import { times } from 'ramda'
 import { useLocale } from '@react-aria/i18n'
 import { CalendarState } from '@react-stately/calendar'
@@ -14,7 +14,7 @@ import { Icon } from '../../../../icon'
 import { Small } from '../../../../typography'
 import { MonthSelect, YearSelectRangeCalendar } from '../date-select'
 import { MonthButton } from './month-button'
-import { getWeekNumberAtStartOfMonth } from './get-week-number-start-of-month'
+import { getDisplayWeek, getWeekNumberAtStartOfMonth } from './get-week-number-start-of-month'
 import { RangeCell } from './range-cell'
 import { DateRangeValue } from '../quick-navigation/types'
 import { FirstDayOfWeek } from './types'
@@ -41,15 +41,10 @@ export const StandaloneCalendarGrid = ({
   const { gridProps, headerProps } = useCalendarGrid(rest, state)
   const weekDays = getWeekdays(firstDayOfWeek)
   const weeksInMonth = getWeeksInMonth(startDate, locale)
-  const weekNumberStart = useMemo(
-    () =>
-      getWeekNumberAtStartOfMonth(
-        startDate.year,
-        startDate.month,
-        getDayOfWeek(startDate, locale)
-      ),
-    [ startDate.year, startDate.month ]
-  )
+  const weekNumberStart = useMemo(() => {
+    const weekNumber = getWeekNumberAtStartOfMonth(startDate.year, startDate.month)
+    return weekNumber
+  }, [ startDate.year, startDate.month ])
 
   return (
     <Box { ...calendarProps } h="265px" p="0">
@@ -75,14 +70,16 @@ export const StandaloneCalendarGrid = ({
           </chakra.thead>
           <chakra.tbody>
             { times((weekIndex) => {
-              const weekNumber = weekNumberStart + weekIndex
-
+              const weekNumber = getDisplayWeek(weekNumberStart,
+                weekIndex,
+                startDate.year,
+                startDate.month)
               return (
                 <chakra.tr key={ weekIndex }>
                   <chakra.td>
                     <Small sx={ { color: 'text.subdued' } } pr="2">
                       w.
-                      { weekNumber > 52 ? weekNumber - 52 : weekNumber }
+                      { weekNumber }
                     </Small>
                   </chakra.td>
                   { state

--- a/framework/lib/components/date-picker/components/calendar/constants.ts
+++ b/framework/lib/components/date-picker/components/calendar/constants.ts
@@ -11,5 +11,4 @@ export const months = [
   'October',
   'November',
   'December',
-  'January',
 ]


### PR DESCRIPTION
This commit resolves the issue where the weeks in the date picker were incorrect. The previous solution did not follow the ISO week numbering rules, resulting in inaccurate week numbers. We are now taking into account the actual calendar days instead of simply counting and dividing by 7. 

https://github.com/user-attachments/assets/ffeb469f-4498-4237-acdc-5ce02a2e6a19

closes: #DEV-17786