### PR TITLE
fix(northlight): toolbox style updates

### DIFF
--- a/framework/lib/components/toolbox/toolbox.tsx
+++ b/framework/lib/components/toolbox/toolbox.tsx
@@ -118,7 +118,7 @@ export const Toolbox = ({
           >
             { isResizable && <ResizeHandle { ...resizeProps } /> }
             <FocusScope autoFocus={ autoFocus }>
-              <VStack width="full" height="full">
+              <VStack w="full" h="full" alignItems="normal">
                 { newChildren }
               </VStack>
             </FocusScope>

--- a/framework/lib/theme/components/toolbox/index.ts
+++ b/framework/lib/theme/components/toolbox/index.ts
@@ -2,21 +2,25 @@ import { ComponentMultiStyleConfig } from '@chakra-ui/react'
 
 export const Toolbox: ComponentMultiStyleConfig = {
   parts: [ 'container', 'header', 'body', 'footer' ],
-  baseStyle: ({ theme: { sizes: sizing } }) => ({
+  baseStyle: ({ theme: {
+    colors: color,
+    sizes: sizing,
+    borders: borderWidth,
+  } }) => ({
     container: {
       position: 'relative',
       bg: 'text.inverted',
       h: '100vh',
-      borderLeftWidth: '1px',
+      borderLeftWidth: borderWidth.xs,
       borderLeftStyle: 'solid',
-      borderLeftColor: 'gray.100',
+      borderLeftColor: color.border.default,
     },
     header: {
       alignItems: 'center',
       height: '16',
-      borderBottomWidth: '1px',
+      borderBottomWidth: borderWidth.xs,
       borderBottomStyle: 'solid',
-      borderBottomColor: 'gray.100',
+      borderBottomColor: color.border.default,
       pl: '4',
       pr: '16',
     },
@@ -27,9 +31,9 @@ export const Toolbox: ComponentMultiStyleConfig = {
       p: '4',
       alignItems: 'center',
       height: '16',
-      borderTopWidth: '1px',
+      borderTopWidth: borderWidth.xs,
       borderTopStyle: 'solid',
-      borderTopColor: 'gray.100',
+      borderTopColor: color.border.default,
     },
     body: {
       p: sizing['4'],


### PR DESCRIPTION
Two updates

1. `borderWidth` & `borderColor` are now updated with semantic tokens
2. Fixed visual bug
**From this:**
<img width="411" alt="Screenshot 2024-12-23 at 16 13 13" src="https://github.com/user-attachments/assets/52fbe509-8c0a-45e5-95ab-e87b31b59a71" />

**To this:**
<img width="424" alt="Screenshot 2024-12-23 at 16 13 03" src="https://github.com/user-attachments/assets/e6b2f974-1701-42bc-8ccf-66070df80044" />

closes: DEV-17582