### PR TITLE
fix(northlight): toast ai desc style

### DIFF
--- a/framework/lib/components/toast/toast.tsx
+++ b/framework/lib/components/toast/toast.tsx
@@ -51,7 +51,15 @@ export const Toast = ({
         ) }
         <Stack spacing={ 0 } alignItems="flex-start">
           { title && <Label size="md">{ title }</Label> }
-          { description && <P>{ description }</P> }
+          { description && (
+          <P
+            sx={ {
+              color: variant === 'ai' ? 'color.text.inverted' : 'text.default',
+            } }
+          >
+            { description }
+          </P>
+          ) }
         </Stack>
 
         <CloseButton


### PR DESCRIPTION
Updated AI variant description styling as per Figma sketches.

Before:
<img width="285" alt="Screenshot 2024-12-27 at 10 04 26" src="https://github.com/user-attachments/assets/b0cd118f-b2e6-44ce-90b4-d22aba0821e5" />
<img width="341" alt="Screenshot 2024-12-27 at 10 04 32" src="https://github.com/user-attachments/assets/56eb0763-7196-4276-9e9c-d3d7423ae94b" />

After:
<img width="303" alt="Screenshot 2024-12-27 at 10 36 38" src="https://github.com/user-attachments/assets/411e04b9-cee8-4147-aa71-810f0bd2d5f8" />
<img width="325" alt="Screenshot 2024-12-27 at 10 36 43" src="https://github.com/user-attachments/assets/0e944ac2-f0f1-401e-bce9-77afab5a92f7" />
