### PR TITLE
fix(northlight): step style updates

### DIFF
--- a/framework/lib/components/steps/step-list.tsx
+++ b/framework/lib/components/steps/step-list.tsx
@@ -9,11 +9,13 @@ import { StepListProps } from './types'
  * @see {@link https://northlight.dev/reference/step-list}
  * @example
  * (?
+ *    <Steps>
         <StepList>
           <Step label="Step 1" description="Name and email" />
           <Step label="Step 2" description="Pick a password" />
           <Step label="Step 3" description="Review" />
         </StepList>
+      </Steps>
  * ?)
  *
  */

--- a/framework/lib/components/steps/step.tsx
+++ b/framework/lib/components/steps/step.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Tab as ChakraStep, useMultiStyleConfig } from '@chakra-ui/react'
+import { Box, Tab as ChakraStep, useMultiStyleConfig } from '@chakra-ui/react'
 import { Capitalized, Lead } from '../typography'
 import { Flex } from '../flex'
 import { ring } from '../../utils'
@@ -11,27 +11,41 @@ import { StepProps } from './types'
  * @see Steps
  * @see {@link https://northlight.dev/reference/step}
  * @example
- * (? <Step label="Step 1" description="Personal information" /> ?)
+ * (?
+ <Steps>
+  <StepList>
+      <Step label="Step 1" description="Personal information" indicator={1} />
+  </StepList>
+</Steps>
+ * ?)
  *
  */
-export const Step = ({ label, description, ...rest }: StepProps) => {
+export const Step = ({ label, description, indicator, ...rest }: StepProps) => {
   const {
     step,
     label: labelStyle,
     description: descriptionStyle,
+    indicator: indicatorStyle,
   } = useMultiStyleConfig('Step')
   return (
     <ChakraStep
       sx={ step }
       { ...rest }
     >
-      <Flex
-        flexDirection="column"
-        alignItems="flex-start"
-        _groupFocusVisible={ ring }
-      >
-        <Capitalized sx={ labelStyle }>{ label }</Capitalized>
-        <Lead sx={ descriptionStyle }>{ description }</Lead>
+      <Flex flexDirection="row" alignItems="flex-start" gap="4" _groupFocusVisible={ ring }>
+        { indicator && (
+          <Box
+            sx={ indicatorStyle }
+            data-part="indicator"
+            justifyContent="center"
+          >
+            { indicator }
+          </Box>
+        ) }
+        <Flex flexDirection="column">
+          <Capitalized sx={ labelStyle }>{ label }</Capitalized>
+          { description && <Lead sx={ descriptionStyle }>{ description }</Lead> }
+        </Flex>
       </Flex>
     </ChakraStep>
   )

--- a/framework/lib/components/steps/steps.tsx
+++ b/framework/lib/components/steps/steps.tsx
@@ -11,9 +11,13 @@ import { StepsProps } from './types'
  * (?
   <Steps>
     <StepList>
-      <Step label="Step 1" description="Name and email" />
-      <Step label="Step 2" description="Pick a password" />
-      <Step label="Step 3" description="Review" />
+      <Step label="Step 1" description="Name and email" indicator={1} />
+      <Step label="Step 2" description="Pick a password" indicator={2}  />
+      <Step label="Step 3"
+      description="Review"
+      indicator={<Icon as={ BrightnessSolid }
+      size="xs" /> }
+      />
     </StepList>
     <StepPanels>
       <StepPanel>1</StepPanel>

--- a/framework/lib/components/steps/types.ts
+++ b/framework/lib/components/steps/types.ts
@@ -1,4 +1,5 @@
 import { TabListProps, TabPanelProps, TabProps, TabsProps } from '@chakra-ui/react'
+import { ReactNode } from 'react'
 
 export type StepListProps = TabListProps
 export interface StepPanelProps extends TabPanelProps {}
@@ -7,4 +8,5 @@ export type StepsProps = TabsProps
 export interface StepProps extends TabProps {
   label: string
   description?: string
+  indicator?: ReactNode
 }

--- a/framework/lib/theme/components/steps/step/index.ts
+++ b/framework/lib/theme/components/steps/step/index.ts
@@ -1,13 +1,8 @@
 import { ComponentMultiStyleConfig } from '@chakra-ui/react'
 
 export const Step: ComponentMultiStyleConfig = {
-  parts: [ 'step', 'label', 'description' ],
-  baseStyle: ({ theme: {
-    colors: color,
-    fontWeights,
-    space: spacing,
-    borders: borderWidth,
-  } }) => ({
+  parts: [ 'step', 'label', 'description', 'indicator' ],
+  baseStyle: ({ theme: { colors: color, fontWeights, space: spacing, borders: borderWidth } }) => ({
     step: {
       justifyContent: 'start',
       alignItems: 'start',
@@ -32,6 +27,9 @@ export const Step: ComponentMultiStyleConfig = {
         bgColor: color.background.step.selected,
         borderColor: color.border.step.selected,
         color: color.border.step.selected,
+        '[data-part="indicator"]': {
+          bg: color.border.step.selected,
+        },
         _hover: {
           borderColor: color.border.step.selected,
           color: color.border.step.selected,
@@ -40,7 +38,6 @@ export const Step: ComponentMultiStyleConfig = {
     },
     label: {
       color: 'inherit',
-      pt: spacing.paddingTop.step.label,
       textAlign: 'start',
       fontWeight: fontWeights.bold,
     },
@@ -48,6 +45,19 @@ export const Step: ComponentMultiStyleConfig = {
       textAlign: 'start',
       fontWeight: fontWeights.semiBold,
       color: color.text.default,
+    },
+    indicator: {
+      minW: 6,
+      minH: 6,
+      borderRadius: 'full',
+      bg: color.text.subdued,
+      color: 'mono.white',
+      fontWeight: fontWeights.bold,
+      fontSize: 'xs',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginTop: '2xs',
     },
   }),
 }


### PR DESCRIPTION
`Step` component styles update 1:1 with Figma requirements

**Enhancements:**
1. Introduced a new `indicator` type/prop, supporting both numbers and icons.
2. Added styling for the indicator to ensure consistent visuals.

**Bug Fixes:**

1. Resolved the issue where clicking a step on NL's website caused it to disappear.

**Refinements:**

1. Updated tokens and improved semantic consistency across styles.


**Video 1** ( `indicator` showoff ):

https://github.com/user-attachments/assets/913878c2-bfbe-4fc0-abfe-b9dfcad8bb37

**Video 2** ( light/dark mode ):

https://github.com/user-attachments/assets/e4237656-84e5-435a-8b4a-bf3fbef0ff19


closes: DEV-17204