### PR TITLE
Add prop to dateRangePicker and dateRangePickerField

### DIFF
--- a/framework/lib/components/date-picker/components/calendar/range-calendar.tsx
+++ b/framework/lib/components/date-picker/components/calendar/range-calendar.tsx
@@ -33,6 +33,7 @@ export const RangeCalendar = (props: RangeCalendarProps) => {
     minValue,
     maxValue,
     firstDayOfWeek,
+    onSave,
   } = props
 
   const { locale } = useLocale()
@@ -87,6 +88,11 @@ export const RangeCalendar = (props: RangeCalendarProps) => {
 
   const focusedStartMonthProps = value && value.start ? {} : focusRing
 
+  const handleSave = () => {
+    onSave?.()
+    handleClose()
+  }
+
   return (
     <Box ref={ ref } __css={ rangeCalendarContainer }>
       <Stack>
@@ -126,7 +132,7 @@ export const RangeCalendar = (props: RangeCalendarProps) => {
                       Clear
                     </Button>
                   ) }
-                  <Button variant="brand" onClick={ handleClose } size="sm">
+                  <Button variant="brand" onClick={ handleSave } size="sm">
                     Save
                   </Button>
                 </HStack>

--- a/framework/lib/components/date-picker/components/calendar/types.ts
+++ b/framework/lib/components/date-picker/components/calendar/types.ts
@@ -9,6 +9,7 @@ export interface RangeCalendarProps extends AriaRangeCalendarProps<DateValue> {
   fiscalStartDay?: number
   isClearable: boolean
   firstDayOfWeek: FirstDayOfWeek
+  onSave?: () => void
 }
 
 export interface CalendarProps extends AriaCalendarProps<DateValue> {

--- a/framework/lib/components/date-picker/date-picker-field/date-range-picker-field.tsx
+++ b/framework/lib/components/date-picker/date-picker-field/date-range-picker-field.tsx
@@ -23,6 +23,7 @@ export const DateRangePickerField = forwardRef<HTMLDivElement, DateRangePickerFi
   firstDayOfWeek = 'monday',
   onChange: onChangeCallback = identity,
   isClearable = true,
+  onSave,
   ...rest
 }, ref) => {
   const { setValue, setError, trigger } = useFormContext<FormBody>()
@@ -63,6 +64,7 @@ export const DateRangePickerField = forwardRef<HTMLDivElement, DateRangePickerFi
           aria-label={ label }
           isInvalid={ !!errors[name] }
           onChange={ handleChange }
+          onSave={ onSave }
           resetDate={ () => onChange(null) }
           value={ value }
           minValue={ minValue }

--- a/framework/lib/components/date-picker/date-picker/date-range-picker.tsx
+++ b/framework/lib/components/date-picker/date-picker/date-range-picker.tsx
@@ -101,6 +101,7 @@ export const DateRangePicker = (props: DateRangePickerProps) => {
     maxValue,
     renderInPortal = false,
     firstDayOfWeek,
+    onSave,
   } = props
   const ref = useRef() as React.MutableRefObject<HTMLInputElement>
   const { group } = useMultiStyleConfig('DatePicker')
@@ -203,6 +204,7 @@ export const DateRangePicker = (props: DateRangePickerProps) => {
                   fiscalStartDay={ fiscalStartDay || 0 }
                   isClearable={ isClearable }
                   firstDayOfWeek={ firstDayOfWeek }
+                  onSave={ onSave }
                 />
               </DatePickerLocaleWrapper>
             </FocusScope>

--- a/framework/lib/components/date-picker/types.ts
+++ b/framework/lib/components/date-picker/types.ts
@@ -35,6 +35,7 @@ export interface DateRangePickerProps
   extends Omit<AriaDateRangePickerProps<DateValue>, 'onChange' | 'value' | 'minValue' | 'maxValue'>,
   DatePickerSettings {
   onChange?: (date: null | DateRange) => void
+  onSave?: () => void
   value: DateRange | null
   minValue?: string | undefined
   maxValue?: string | undefined
@@ -54,6 +55,7 @@ export interface DatePickerFieldProps
   direction?: StackDirection
   dateFormat?: string
   onChange?: (date: DateValue) => void
+  onSave?: () => void
   isClearable?: boolean
   fiscalStartMonth?: number
   fiscalStartDay?: number


### PR DESCRIPTION
This allows us to execute functions whenever the Save button is pressed. Previously we did not support this, and only closed the modal whenever Save was pressed