### PR TITLE
fix(northlight-ui): update type in flipbuttongroupfield

### DIFF
--- a/framework/lib/components/flip-button/types.ts
+++ b/framework/lib/components/flip-button/types.ts
@@ -95,6 +95,6 @@ export interface FlipButtonGroupFieldProps extends FlipButtonGroupProps {
   label: string
   isRequired?: boolean
   validate?: RegisterOptions
-  value?: string
+  value?: string | string[]
   iconPlacement?: 'left' | 'right' | 'none'
 }


### PR DESCRIPTION
This commit resolves the issue where the FlipButtonGroupField wouldnt show all the values. This was due to the props not being able to take string[] which can be the case when selecting datasets in reports for example. Ive added the possibility to pass string[] aswell to the value so we can now pass array with string. 

closes: #DEV-19393