### PR TITLE
fix(framework): flipbutton showed DOM error messages

### DIFF
--- a/framework/lib/components/flip-button/flip-button.tsx
+++ b/framework/lib/components/flip-button/flip-button.tsx
@@ -153,11 +153,7 @@ export const FlipButton = (props: FlipButtonProps) => {
       state,
       containerProps,
       flipButtonProps,
-      isFocused,
       isSelected,
-      isDisabled,
-      isMulti: isMulti || false,
-      focusRing,
       value,
       ...rest,
     })

--- a/framework/lib/components/flip-button/types.ts
+++ b/framework/lib/components/flip-button/types.ts
@@ -58,11 +58,7 @@ export interface CustomFlipButtonProps {
   state: CheckboxGroupState | RadioGroupState | null
   flipButtonProps: CustomFlipButtonPropsType
   containerProps: CustomContainerPropsType
-  isFocused: boolean
   isSelected: boolean
-  isDisabled: boolean
-  isMulti: boolean
-  focusRing: FocusRingType
   label?: string
   value: string
 }


### PR DESCRIPTION
We were sending props to the children
which where already handled in containerProps and flipButtonProps, these where then applied wrongfully directly on DOM elements.

Closes: DEV-9085