### PR TITLE
fix(framework): change keyframes import to emotion

### DIFF
--- a/framework/lib/components/keyframes/index.ts
+++ b/framework/lib/components/keyframes/index.ts
@@ -1,3 +1,3 @@
 export {
   keyframes,
-} from '@chakra-ui/react'
+} from '@emotion/react'

--- a/framework/lib/theme/components/blinker/index.ts
+++ b/framework/lib/theme/components/blinker/index.ts
@@ -1,4 +1,5 @@
-import { ComponentSingleStyleConfig, keyframes } from '@chakra-ui/react'
+import { ComponentSingleStyleConfig } from '@chakra-ui/react'
+import { keyframes } from '@emotion/react'
 
 const pulseRing = keyframes`
 0% {

--- a/framework/lib/theme/components/file-picker/index.ts
+++ b/framework/lib/theme/components/file-picker/index.ts
@@ -1,5 +1,5 @@
-import { ComponentMultiStyleConfig, keyframes } from '@chakra-ui/react'
-import { CSSObject } from '@emotion/react'
+import { ComponentMultiStyleConfig } from '@chakra-ui/react'
+import { CSSObject, keyframes } from '@emotion/react'
 import { merge } from 'ramda'
 import { CurrentTheme } from '../../../utils'
 


### PR DESCRIPTION
This commit imports keyframes from @emotion/react instead of @chakra-ui. This will allow exporting the keyframes directly from emotion.