### PR TITLE
feat(framework): ignore firstDayOfWeek prop from react-aria

### DIFF
--- a/framework/lib/components/date-picker/types.ts
+++ b/framework/lib/components/date-picker/types.ts
@@ -28,11 +28,11 @@ interface DatePickerSettings {
 }
 
 export interface DatePickerProps
-  extends AriaDatePickerProps<DateValue>,
+  extends Omit<AriaDatePickerProps<DateValue>, 'firstDayOfWeek'>,
   DatePickerSettings {}
 
 export interface DateRangePickerProps
-  extends Omit<AriaDateRangePickerProps<DateValue>, 'onChange' | 'value' | 'minValue' | 'maxValue'>,
+  extends Omit<AriaDateRangePickerProps<DateValue>, 'firstDayOfWeek' | 'onChange' | 'value' | 'minValue' | 'maxValue'>,
   DatePickerSettings {
   onChange?: (date: null | DateRange) => void
   onSave?: () => void


### PR DESCRIPTION
This commit ignores the prop firstDayOfWeek that react-aria implements in v3.X.X. When installing the latest minor version the props will clash with the one defined in northlight.