### PR TITLE
fix(northlight): input focus ring stays within boundaries

### DIFF
--- a/framework/lib/theme/components/input/index.ts
+++ b/framework/lib/theme/components/input/index.ts
@@ -37,8 +37,9 @@ export const Input: ComponentMultiStyleConfig = {
         _focusVisible: {
           bgColor: color.background.input['outline-focus'],
           borderColor: color.border.input.focus,
+          boxShadow: `inset 0 0 0 1px ${color.border.input.focus}`,
           _invalid: {
-            boxShadow: `0 0 0 1px ${color.border.input.error}`,
+            boxShadow: `inset 0 0 0 1px ${color.border.input.error}`,
             bgColor: color.background.input['outline-error'],
             borderColor: color.border.input.error,
           },
@@ -50,6 +51,7 @@ export const Input: ComponentMultiStyleConfig = {
         _invalid: {
           bgColor: color.background.input['outline-error'],
           borderColor: color.border.input.error,
+          boxShadow: `inset 0 0 0 1px ${color.border.input.error}`,
         },
         _disabled: {
           bgColor: color.background.input['outline-disabled'],
@@ -88,20 +90,20 @@ export const Input: ComponentMultiStyleConfig = {
           bgColor: color.background.input['filled-hover'],
         },
         _focusVisible: {
-          boxShadow: `0 0 0 1px ${color.border.input.focus}`,
+          boxShadow: `inset 0 0 0 1px ${color.border.input.focus}`,
           borderColor: color.border.input.focus,
           bgColor: color.background.input['filled-focus'],
           _readOnly: {
             bgColor: color.background.input['filled-default'],
           },
           _invalid: {
-            boxShadow: `0 0 0 1px ${color.border.input.error}`,
+            boxShadow: `inset 0 0 0 1px ${color.border.input.error}`,
             bgColor: color.background.input['outline-error'],
             borderColor: color.border.input.error,
           },
         },
         _invalid: {
-          boxShadow: `0 0 0 1px ${color.border.input.error}`,
+          boxShadow: `inset 0 0 0 1px ${color.border.input.error}`,
           bgColor: color.background.input['filled-error'],
           borderColor: color.border.input.error,
         },
@@ -188,11 +190,11 @@ export const Input: ComponentMultiStyleConfig = {
         _focusVisible: {
           bgColor: color.background.input['outline-focus'],
           _hover: {
-            boxShadow: `0 0 0 1px ${color.border.ai}`,
+            boxShadow: `inset 0 0 0 1px ${color.border.ai}`,
             borderColor: color.border.ai,
           },
           _invalid: {
-            boxShadow: `0 0 0 1px ${color.border.input.error}`,
+            boxShadow: `inset 0 0 0 1px ${color.border.input.error}`,
             bgColor: color.background.input['outline-error'],
             borderColor: color.border.input.error,
           },

--- a/framework/lib/theme/components/number-input/index.ts
+++ b/framework/lib/theme/components/number-input/index.ts
@@ -52,12 +52,12 @@ export const NumberInput: ComponentMultiStyleConfig = {
       _focusVisible: {
         bg: color.background.input['outline-focus'],
         borderColor: color.border.input.focus,
-        boxShadow: `0 0 0 1px ${color.border.textarea.focus}`,
+        boxShadow: `inset 0 0 0 1px ${color.border.textarea.focus}`,
       },
       _invalid: {
         bg: color.background.input['outline-error'],
         borderColor: color.border.input.error,
-        boxShadow: `0 0 0 1px ${color.border.input.error}`,
+        boxShadow: `inset 0 0 0 1px ${color.border.input.error}`,
       },
       _disabled: {
         bg: color.background.input['outline-disabled'],


### PR DESCRIPTION
This commit fixes the issue where the boxShadow on focused `Input` and `NumberInput` components would overflow or get clipped by their parent wrappers.

The fix uses an `inset` boxShadow to keep the focus ring visually contained within the input boundaries, ensuring a cleaner and more consistent appearance across layouts.

**Before:**
<img width="159" alt="Screenshot 2025-05-21 at 11 36 58" src="https://github.com/user-attachments/assets/419d0742-b3d0-4625-b788-18a51df9bae9" />
<img width="236" alt="Screenshot 2025-05-21 at 11 02 49" src="https://github.com/user-attachments/assets/6da0b923-97ed-485a-92ac-dfec5f585cba" />

**After:**
<img width="435" alt="Screenshot 2025-05-21 at 13 15 23" src="https://github.com/user-attachments/assets/3e79bba1-3119-4197-a3dc-110159f4d493" />
<img width="530" alt="Screenshot 2025-05-21 at 13 17 47" src="https://github.com/user-attachments/assets/8c2272e7-27d9-4d70-bc32-e7fa4be1182e" />

closes: DEV-8022
