### PR TITLE
fix(northlight): daterange input focus ring

### DIFF
--- a/framework/lib/theme/components/date-picker/index.ts
+++ b/framework/lib/theme/components/date-picker/index.ts
@@ -13,10 +13,10 @@ export const DatePicker: ComponentMultiStyleConfig = {
       _focusWithin: {
         bgColor: color.background.input['outline-focus'],
         borderColor: color.border.textarea.focus,
-        boxShadow: `0 0 0 1px ${color.border.textarea.focus}`,
+        boxShadow: `inset 0 0 0 1px ${color.border.textarea.focus}`,
       },
       _invalid: {
-        boxShadow: `0 0 0 1px ${color.border.input.error}`,
+        boxShadow: `inset 0 0 0 1px ${color.border.input.error}`,
         borderColor: color.border.input.error,
       },
       _disabled: {
@@ -37,11 +37,11 @@ export const DatePicker: ComponentMultiStyleConfig = {
       outline: 'none',
       rounded: 'md',
       _focus: {
-        bgColor: 'blue.500',
+        bgColor: 'bg.brand.default',
         color: color.text.inverted,
       },
       _placeholder: {
-        color: 'red.500',
+        color: 'destructive',
       },
     },
   }),


### PR DESCRIPTION
preventing layout clipping while preserving the intended highlight effect.

Before:
<img width="267" alt="Screenshot 2025-05-21 at 15 52 35" src="https://github.com/user-attachments/assets/395c8609-f3d5-4672-8100-6403ac9d972c" />

After:
<img width="513" alt="Screenshot 2025-05-21 at 15 48 01" src="https://github.com/user-attachments/assets/c8925184-6b50-4221-9a36-f271809d2a61" />
