### PR TITLE
feat(northlight): alert doc page

### DIFF
--- a/framework/lib/components/alert/alert.tsx
+++ b/framework/lib/components/alert/alert.tsx
@@ -2,6 +2,57 @@ import React from 'react'
 import { Alert as ChakraAlert } from '@chakra-ui/react'
 import { AlertProps } from './types'
 
+/**
+ * @example (Example)
+ * ## Usage
+ * <br />
+ * Northlight exports 4 alert related components: <br />
+ * <br />
+ * `Alert`: The wrapper for alert components. <br />
+ * `AlertIcon`: The visual icon for the alert that changes based on the status prop. <br />
+ * `AlertTitle`: The title of the alert to be announced by screen readers. <br />
+ * `AlertDescription`: The description of the alert to be announced by screen readers. <br />
+ * <br />
+ * (?
+ * +
+ * const toastIconMap = {
+ *   success: CheckCircleSolid,
+ *   warning: AlertTriangleSolid,
+ *   error: AlertCircleSolid,
+ *   danger: AlertCircleSolid,
+ *   info: BellSolid,
+ *   ai: BrightnessSolid,
+ *   default: HelpCircleSolid,
+ *   ghost: HelpCircleSolid,
+ * }
+ *
+ * const variants = [
+ *   "default",
+ *   "success",
+ *   "warning",
+ *   "error",
+ *   "info",
+ *   "ai",
+ *   "ghost",
+ * ]
+ *
+ * const Example = () => (
+ *   <SimpleGrid columns={2} columnGap="2" rowGap="4">
+ *
+ *     {variants.map((variant) => (
+ *       <Alert variant={variant}>
+ *         <AlertIcon as={toastIconMap[variant]} />
+ *         <AlertTitle>Title</AlertTitle>
+ *         <AlertDescription>Description</AlertDescription>
+ *       </Alert>
+ *     ))}
+ *   </SimpleGrid>
+ * )
+ * render(<Example />)
+
+ * ?)
+ */
+
 export const Alert = ({
   variant = 'success',
   children,

--- a/framework/lib/theme/components/alert/index.ts
+++ b/framework/lib/theme/components/alert/index.ts
@@ -1,7 +1,7 @@
 import { ComponentMultiStyleConfig } from '@chakra-ui/react'
 
 export const Alert: ComponentMultiStyleConfig = {
-  parts: [ 'container', 'title', 'description' ],
+  parts: [ 'container', 'title', 'description', 'icon' ],
   baseStyle: ({ theme: {
     radii: borderRadius,
     colors: color,
@@ -14,21 +14,33 @@ export const Alert: ComponentMultiStyleConfig = {
       width: 'auto',
       display: 'flex',
     },
+    icon: {
+      boxSize: 6,
+    },
   }),
   variants: {
     success: ({ theme: { colors: color } }) => ({
       container: {
         bgColor: color.background.toast.success,
       },
+      icon: {
+        color: color.icon.toast.success,
+      },
     }),
     warning: ({ theme: { colors: color } }) => ({
       container: {
         bgColor: color.background.toast.warning,
       },
+      icon: {
+        color: color.icon.toast.warning,
+      },
     }),
     info: ({ theme: { colors: color } }) => ({
       container: {
         bgColor: color.background.toast.info,
+      },
+      icon: {
+        color: color.icon.toast.info,
       },
     }),
     error: ({ theme: { colors: color } }) => ({
@@ -36,17 +48,26 @@ export const Alert: ComponentMultiStyleConfig = {
         bgColor: color.background.toast.error,
         color: color.text.toast.error,
       },
+      icon: {
+        color: color.icon.toast.error,
+      },
     }),
     ai: ({ theme: { colors: color } }) => ({
       container: {
         bgColor: color.bg.ai.default,
         color: color.text.inverted,
       },
+      icon: {
+        color: color.icon.toast.ai,
+      },
     }),
     default: ({ theme: { colors: color } }) => ({
       container: {
         bgColor: color.bg.layer,
         color: color.text.default,
+      },
+      icon: {
+        color: color.icon.toast.default,
       },
     }),
     ghost: ({ theme: { colors: color } }) => ({
@@ -56,6 +77,9 @@ export const Alert: ComponentMultiStyleConfig = {
         borderWidth: 'xs',
         borderColor: color.border.default,
         borderStyle: 'solid',
+      },
+      icon: {
+        color: color.icon.toast.ghost,
       },
     }),
   },


### PR DESCRIPTION
This commit adds: 
1. Usage page for the `<Alert>`
2. Updated styling for the icons

<img width="983" alt="Screenshot 2025-05-22 at 12 02 54" src="https://github.com/user-attachments/assets/088b4ac8-4ffb-46f2-bd4a-324ae9858466" />
<img width="878" alt="Screenshot 2025-05-22 at 12 05 39" src="https://github.com/user-attachments/assets/6c689b3a-5b88-480a-89ad-fef184fb873e" />
