### PR TITLE
fix(northlight): numberInput token fix

### DIFF
--- a/framework/lib/components/number-input/number-input-stepper.tsx
+++ b/framework/lib/components/number-input/number-input-stepper.tsx
@@ -19,7 +19,7 @@ export const NumberInputStepper = ({
   <ChakraNumberInputStepper>
     <HStack alignItems="center" h="full">
       { includePercentage && (
-        <Center bgColor="gray.50" borderRadius="md" boxSize="6">
+        <Center bgColor="bg.layer" borderRadius="md" boxSize="6">
           <P>%</P>
         </Center>
       ) }


### PR DESCRIPTION
Fixes the percentage badge issue in dark mode because reference token was assigned instead of a semantic token.

<img width="406" height="200" alt="Screenshot 2025-07-30 at 08 27 29" src="https://github.com/user-attachments/assets/e5e1c592-5a45-4110-97f3-192ef0e48830" />
