### PR TITLE
fix(framework): handle drag actions in outside ref click

### DIFF
--- a/framework/lib/hooks/use-outside-rect-click/index.ts
+++ b/framework/lib/hooks/use-outside-rect-click/index.ts
@@ -3,10 +3,41 @@ import { MutableRefObject, useEffect, useRef } from 'react'
 
 const isBetween = (point: number, min: number, max: number) => (point >= min && point <= max)
 
+const isEventInsideRect = (
+  ref:MutableRefObject<HTMLElement>,
+  event: MouseEvent | TouchEvent
+) => {
+  let clientX
+  let clientY
+
+  if (event instanceof MouseEvent) {
+    clientX = event.clientX
+    clientY = event.clientY
+  } else if (event instanceof TouchEvent && event.changedTouches[0]) {
+    clientX = event.changedTouches[0].clientX
+    clientY = event.changedTouches[0].clientY
+  }
+
+  if (isNil(clientX) || isNil(clientY)) return true
+
+  const {
+    top,
+    right,
+    left,
+    bottom,
+  } = ref.current.getBoundingClientRect()
+
+  return isBetween(clientX, left, right) && isBetween(clientY, top, bottom)
+}
+
+const isHtmlElementRef =
+  (ref: MutableRefObject<HTMLElement | null>): ref is MutableRefObject<HTMLElement> =>
+    !isNil(ref.current)
+
 export const useOutsideRectClick =
 (ref: MutableRefObject<HTMLElement | null>, callback: (event: MouseEvent | TouchEvent) => void) => {
   const stateRef = useRef({
-    isPointerDown: false,
+    isPointerDownOutsideRect: false,
     ignoreEmulatedMouseEvents: false,
   })
 
@@ -14,36 +45,22 @@ export const useOutsideRectClick =
 
   useEffect(() => {
     const handleMouseClick = (event: MouseEvent | TouchEvent) => {
-      let clientX
-      let clientY
-
-      if (event instanceof MouseEvent) {
-        clientX = event.clientX
-        clientY = event.clientY
-      } else if (event instanceof TouchEvent && event.changedTouches[0]) {
-        clientX = event.changedTouches[0].clientX
-        clientY = event.changedTouches[0].clientY
+      if (!isHtmlElementRef(ref)) {
+        return
       }
-
-      if (isNil(clientX) || isNil(clientY)) return
-
-      if (isNil(ref?.current)) return
-
-      const {
-        top,
-        right,
-        left,
-        bottom,
-      } = ref.current.getBoundingClientRect()
-
-      const isInBound = isBetween(clientX, left, right) && isBetween(clientY, top, bottom)
+      const isInBound = isEventInsideRect(ref, event)
 
       if (isInBound) return
       callback(event)
     }
 
-    const onPointerDown: any = () => {
-      state.isPointerDown = true
+    const onPointerDown: any = (event: MouseEvent | TouchEvent) => {
+      if (!isHtmlElementRef(ref)) {
+        return
+      }
+      if (!isEventInsideRect(ref, event)) {
+        state.isPointerDownOutsideRect = true
+      }
     }
 
     const onMouseUp: any = (event: MouseEvent) => {
@@ -52,16 +69,16 @@ export const useOutsideRectClick =
         return
       }
 
-      if (state.isPointerDown) {
-        state.isPointerDown = false
+      if (state.isPointerDownOutsideRect) {
+        state.isPointerDownOutsideRect = false
         handleMouseClick(event)
       }
     }
 
     const onTouchEnd = (event: TouchEvent) => {
       state.ignoreEmulatedMouseEvents = true
-      if (state.isPointerDown) {
-        state.isPointerDown = false
+      if (state.isPointerDownOutsideRect) {
+        state.isPointerDownOutsideRect = false
         handleMouseClick(event)
       }
     }

--- a/framework/test/unit/hooks/use-outside-rect-click-test.ts
+++ b/framework/test/unit/hooks/use-outside-rect-click-test.ts
@@ -45,6 +45,21 @@ describe('useOutsideRectClick', () => {
     assert.isNull(result)
   })
 
+  it('should not call the callback when mousedown is triggered inside and mouseUp is released outside', async () => {
+    renderHook(
+      () => useOutsideRectClick(ref, () => {
+        result = 'clicked inside'
+      })
+    )
+
+    act(() => {
+      fireEvent.mouseDown(document, { clientX: 0, clientY: 0 })
+      fireEvent.mouseUp(document, { clientX: 10, clientY: 10 })
+    })
+
+    assert.isNull(result)
+  })
+
   it('should call the callback when touchEnd is released outside', async () => {
     renderHook(
       () => useOutsideRectClick(ref, () => {
@@ -70,6 +85,21 @@ describe('useOutsideRectClick', () => {
     act(() => {
       fireEvent.touchStart(document, { changedTouches: [ { clientX: 0, clientY: 0 } ] })
       fireEvent.touchEnd(document, { changedTouches: [ { clientX: 0, clientY: 0 } ] })
+    })
+
+    assert.isNull(result)
+  })
+
+  it('should not call the callback when touchStart is triggered inside and touchEnd is released outside', async () => {
+    renderHook(
+      () => useOutsideRectClick(ref, () => {
+        result = 'clicked inside'
+      })
+    )
+
+    act(() => {
+      fireEvent.touchStart(document, { changedTouches: [ { clientX: 0, clientY: 0 } ] })
+      fireEvent.touchEnd(document, { changedTouches: [ { clientX: 10, clientY: 10 } ] })
     })
 
     assert.isNull(result)


### PR DESCRIPTION
when mousedown occurs inside the referenced element do not trigger callback if mouseup occurs outside element. this is to prevent for example behaviour where user clicks down inside an input field and drags to highlight text and releases mouse outside element