### PR TITLE
chore(northlight): text contrast adjustment

### DIFF
--- a/framework/lib/theme/components/badge/index.ts
+++ b/framework/lib/theme/components/badge/index.ts
@@ -19,16 +19,19 @@ export const Badge: ComponentSingleStyleConfig = {
     }
   },
   variants: {
-    solid: ({ colorScheme, theme: { colors }, currentTheme }) => {
+    solid: ({ colorScheme, theme: { colors }, currentTheme, bg, bgColor }) => {
       const processedColorScheme = processColorSchemeBasedOnTheme({ currentTheme, colorScheme })
 
-      const bgColor = processedColorScheme === 'mediatoolBlue'
-        ? colors[processedColorScheme][500]
-        : colors[processedColorScheme] && colors[processedColorScheme][500]
+      const finalBg =
+    bg ??
+    bgColor ??
+    (processedColorScheme === 'mediatoolBlue'
+      ? colors[processedColorScheme][500]
+      : colors[processedColorScheme] && colors[processedColorScheme][500])
 
       return {
-        bgColor,
-        color: getContrastColor(bgColor ?? useToken('colors', processedColorScheme)),
+        bgColor: finalBg,
+        color: getContrastColor(finalBg ?? useToken('colors', processedColorScheme)),
       }
     },
     outline: ({ colorScheme, theme: { colors }, currentTheme }) => {
@@ -72,5 +75,6 @@ export const Badge: ComponentSingleStyleConfig = {
   },
   defaultProps: {
     size: 'sm',
+    variant: 'solid',
   },
 }

--- a/framework/lib/theme/components/tag/index.ts
+++ b/framework/lib/theme/components/tag/index.ts
@@ -30,11 +30,13 @@ export const Tag: ComponentMultiStyleConfig = {
     solid: ({ theme: { colors }, bgColor, colorScheme, currentTheme }) => {
       const processedColorScheme = processColorSchemeBasedOnTheme({ currentTheme, colorScheme })
 
-      const tagBgColor =
+      const tagBgColorRaw =
         bgColor ??
         (colors[processedColorScheme] && colors[processedColorScheme][500]
           ? colors[processedColorScheme][500]
           : processedColorScheme)
+
+      const tagBgColor = typeof tagBgColorRaw === 'string' ? tagBgColorRaw.trim() : tagBgColorRaw
 
       const tagColor = getContrastColor(useToken('colors', tagBgColor))
 
@@ -48,11 +50,13 @@ export const Tag: ComponentMultiStyleConfig = {
     subtle: ({ theme: { colors }, colorScheme, bgColor, currentTheme }) => {
       const processedColorScheme = processColorSchemeBasedOnTheme({ currentTheme, colorScheme })
 
-      const tagBgColor =
+      const tagBgColorRaw =
         bgColor ??
         (colors[processedColorScheme] && colors[processedColorScheme][100]
           ? colors[processedColorScheme][100]
           : processedColorScheme)
+
+      const tagBgColor = typeof tagBgColorRaw === 'string' ? tagBgColorRaw.trim() : tagBgColorRaw
 
       const tagColor = getContrastColor(useToken('colors', tagBgColor))
 

--- a/framework/lib/utils/luminosity/index.ts
+++ b/framework/lib/utils/luminosity/index.ts
@@ -1,15 +1,15 @@
 export const luminosity = (hexcolor: string) => {
-  let color = hexcolor
+  if (!hexcolor || typeof hexcolor !== 'string') return Number.NaN
 
-  if (color.slice(0, 1) === '#') {
-    color = color.slice(1)
+  let color = hexcolor.trim()
+
+  if (!/^#?[0-9a-f]{3}([0-9a-f]{3})?$/i.test(color)) {
+    return Number.NaN
   }
 
+  if (color[0] === '#') color = color.slice(1)
   if (color.length === 3) {
-    color = color
-      .split('')
-      .map((hex) => hex + hex)
-      .join('')
+    color = color.split('').map((h) => h + h).join('')
   }
 
   const r = parseInt(color.substring(0, 2), 16)


### PR DESCRIPTION
Fixes the issue where an undefined light background from `<Badge>` and `<Tag>` returns white text.


https://github.com/user-attachments/assets/e8cd1f24-4c5e-45dd-ba17-c5c8ee7af9eb


https://github.com/user-attachments/assets/53938349-2cae-40c3-9588-a4ad97b231ba

