### PR TITLE
fix (tokens): accent colors

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.11.5](https://github.com/mediatool/northlight/compare/@northlight/docs@1.11.4...@northlight/docs@1.11.5) (2025-08-27)
+
+**Note:** Version bump only for package @northlight/docs
+
+
+
+
+
 ## [1.11.4](https://github.com/mediatool/northlight/compare/@northlight/docs@1.11.3...@northlight/docs@1.11.4) (2025-08-18)
 
 **Note:** Version bump only for package @northlight/docs

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@northlight/docs",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "main": "index.ts",
   "license": "UNLICENSED",
   "private": true,
@@ -32,7 +32,7 @@
     "@emotion/react": "^11.11.1",
     "@northlight/icons": "^1.6.5",
     "@northlight/tokens": "^1.4.6",
-    "@northlight/ui": "^2.36.10",
+    "@northlight/ui": "^2.36.11",
     "@react-aria/i18n": "^3.8.2",
     "@shopify/react-i18n": "^7.7.2",
     "chakra-react-select": "^4.4.3",

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.36.11](https://github.com/mediatool/northlight/compare/@northlight/ui@2.36.10...@northlight/ui@2.36.11) (2025-08-27)
+
+
+### Bug Fixes
+
+* **northlight:** brandSubdued token ([19ab647](https://github.com/mediatool/northlight/commit/19ab64787e2feadfd924f235575860d0ee86a55d))
+
+
+
+
+
 ## [2.36.10](https://github.com/mediatool/northlight/compare/@northlight/ui@2.36.9...@northlight/ui@2.36.10) (2025-08-18)
 
 

--- a/framework/lib/theme/components/badge/index.ts
+++ b/framework/lib/theme/components/badge/index.ts
@@ -19,16 +19,19 @@ export const Badge: ComponentSingleStyleConfig = {
     }
   },
   variants: {
-    solid: ({ colorScheme, theme: { colors }, currentTheme }) => {
+    solid: ({ colorScheme, theme: { colors }, currentTheme, bg, bgColor }) => {
       const processedColorScheme = processColorSchemeBasedOnTheme({ currentTheme, colorScheme })
 
-      const bgColor = processedColorScheme === 'mediatoolBlue'
-        ? colors[processedColorScheme][500]
-        : colors[processedColorScheme] && colors[processedColorScheme][500]
+      const finalBg =
+    bg ??
+    bgColor ??
+    (processedColorScheme === 'mediatoolBlue'
+      ? colors[processedColorScheme][500]
+      : colors[processedColorScheme] && colors[processedColorScheme][500])
 
       return {
-        bgColor,
-        color: getContrastColor(bgColor ?? useToken('colors', processedColorScheme)),
+        bgColor: finalBg,
+        color: getContrastColor(finalBg ?? useToken('colors', processedColorScheme)),
       }
     },
     outline: ({ colorScheme, theme: { colors }, currentTheme }) => {
@@ -72,5 +75,6 @@ export const Badge: ComponentSingleStyleConfig = {
   },
   defaultProps: {
     size: 'sm',
+    variant: 'solid',
   },
 }

--- a/framework/lib/theme/components/tag/index.ts
+++ b/framework/lib/theme/components/tag/index.ts
@@ -30,11 +30,13 @@ export const Tag: ComponentMultiStyleConfig = {
     solid: ({ theme: { colors }, bgColor, colorScheme, currentTheme }) => {
       const processedColorScheme = processColorSchemeBasedOnTheme({ currentTheme, colorScheme })
 
-      const tagBgColor =
+      const tagBgColorRaw =
         bgColor ??
         (colors[processedColorScheme] && colors[processedColorScheme][500]
           ? colors[processedColorScheme][500]
           : processedColorScheme)
+
+      const tagBgColor = typeof tagBgColorRaw === 'string' ? tagBgColorRaw.trim() : tagBgColorRaw
 
       const tagColor = getContrastColor(useToken('colors', tagBgColor))
 
@@ -48,11 +50,13 @@ export const Tag: ComponentMultiStyleConfig = {
     subtle: ({ theme: { colors }, colorScheme, bgColor, currentTheme }) => {
       const processedColorScheme = processColorSchemeBasedOnTheme({ currentTheme, colorScheme })
 
-      const tagBgColor =
+      const tagBgColorRaw =
         bgColor ??
         (colors[processedColorScheme] && colors[processedColorScheme][100]
           ? colors[processedColorScheme][100]
           : processedColorScheme)
+
+      const tagBgColor = typeof tagBgColorRaw === 'string' ? tagBgColorRaw.trim() : tagBgColorRaw
 
       const tagColor = getContrastColor(useToken('colors', tagBgColor))
 

--- a/framework/lib/utils/luminosity/index.ts
+++ b/framework/lib/utils/luminosity/index.ts
@@ -1,15 +1,15 @@
 export const luminosity = (hexcolor: string) => {
-  let color = hexcolor
+  if (!hexcolor || typeof hexcolor !== 'string') return Number.NaN
 
-  if (color.slice(0, 1) === '#') {
-    color = color.slice(1)
+  let color = hexcolor.trim()
+
+  if (!/^#?[0-9a-f]{3}([0-9a-f]{3})?$/i.test(color)) {
+    return Number.NaN
   }
 
+  if (color[0] === '#') color = color.slice(1)
   if (color.length === 3) {
-    color = color
-      .split('')
-      .map((hex) => hex + hex)
-      .join('')
+    color = color.split('').map((h) => h + h).join('')
   }
 
   const r = parseInt(color.substring(0, 2), 16)

--- a/framework/package.json
+++ b/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@northlight/ui",
-  "version": "2.36.10",
+  "version": "2.36.11",
   "description": "Northlight UI library, based on Chakra-ui",
   "license": "MIT",
   "author": "Camphouse",

--- a/tokens/lib/tokens.json
+++ b/tokens/lib/tokens.json
@@ -4351,7 +4351,7 @@
               "type": "color"
             },
             "ai": {
-              "value": "{color.coral.600}",
+              "value": "{color.moss.600}",
               "type": "color"
             }
           },

--- a/tokens/lib/tokens.json
+++ b/tokens/lib/tokens.json
@@ -4223,7 +4223,7 @@
           },
           "secondary": {
             "default": {
-              "value": "{color.coral.300}",
+              "value": "{color.coral.400}",
               "type": "color"
             },
             "hover": {
@@ -4295,35 +4295,35 @@
         "text": {
           "over": {
             "success": {
-              "value": "{color.green.800}",
+              "value": "{color.moss.800}",
               "type": "color"
             },
             "error": {
-              "value": "{color.rose.700}",
+              "value": "{color.red.800}",
               "type": "color"
             },
             "warning": {
-              "value": "{color.coral.700}",
+              "value": "{color.coral.800}",
               "type": "color"
             },
             "info": {
-              "value": "{color.smoke.900}",
+              "value": "{color.coral.800}",
               "type": "color"
             },
             "brand": {
-              "value": "{st.color.brand}",
+              "value": "{color.inkBlue.800}",
               "type": "color"
             },
             "secondary": {
-              "value": "{color.coral.700}",
+              "value": "{color.coral.800}",
               "type": "color"
             },
             "tertiary": {
-              "value": "{st.color.inverted-alt}",
+              "value": "{color.smoke.800}",
               "type": "color"
             },
             "ai": {
-              "value": "{st.color.brand}",
+              "value": "{color.moss.800}",
               "type": "color"
             }
           },
@@ -4343,7 +4343,7 @@
               "type": "color"
             },
             "danger": {
-              "value": "{st.color.destructive}",
+              "value": "{color.red.600}",
               "type": "color"
             },
             "success": {
@@ -4351,7 +4351,7 @@
               "type": "color"
             },
             "ai": {
-              "value": "{color.coral.500}",
+              "value": "{color.coral.600}",
               "type": "color"
             }
           },

--- a/tokens/lib/tokens.json
+++ b/tokens/lib/tokens.json
@@ -2999,15 +2999,15 @@
           },
           "secondary": {
             "default": {
-              "value": "{color.green.500}",
+              "value": "{color.blue.500}",
               "type": "color"
             },
             "active": {
-              "value": "{color.green.500}",
+              "value": "{color.blue.500}",
               "type": "color"
             },
             "hover": {
-              "value": "{color.green.500}{alpha.hover-full}",
+              "value": "{color.blue.500}{alpha.hover-full}",
               "type": "color"
             }
           },
@@ -5411,6 +5411,10 @@
           },
           "link": {
             "value": "{st.color.text.link.default}",
+            "type": "color"
+          },
+          "accent": {
+            "value": "{st.color.bg.secondary.default}",
             "type": "color"
           },
           "link-hover": {

--- a/tokens/lib/tokens.json
+++ b/tokens/lib/tokens.json
@@ -2999,7 +2999,7 @@
           },
           "secondary": {
             "default": {
-              "value": "{color.green.500}",
+              "value": "{color.blue.500}",
               "type": "color"
             },
             "active": {

--- a/tokens/lib/tokens.json
+++ b/tokens/lib/tokens.json
@@ -2999,15 +2999,15 @@
           },
           "secondary": {
             "default": {
-              "value": "{color.blue.500}",
+              "value": "{color.green.500}",
               "type": "color"
             },
             "active": {
-              "value": "{color.blue.500}",
+              "value": "{color.green.500}",
               "type": "color"
             },
             "hover": {
-              "value": "{color.blue.500}{alpha.hover-full}",
+              "value": "{color.green.500}{alpha.hover-full}",
               "type": "color"
             }
           },
@@ -3347,7 +3347,7 @@
               "type": "color"
             },
             "tertiary": {
-              "value": "{color.mediatoolBlue.800}",
+              "value": "{color.mono.white}",
               "type": "color"
             },
             "ai": {
@@ -5427,6 +5427,14 @@
           },
           "brandSubdued": {
             "value": "{color.text.brand}",
+            "type": "color"
+          },
+          "sidebar": {
+            "value": "{color.text.default}",
+            "type": "color"
+          },
+          "sidebar-active": {
+            "value": "{st.color.text.over.tertiary}",
             "type": "color"
           },
           "brand": {

--- a/tokens/lib/tokens.json
+++ b/tokens/lib/tokens.json
@@ -2030,11 +2030,11 @@
               "type": "color"
             },
             "active": {
-              "value": "{color.green.400}",
+              "value": "{st.color.bg.secondary.default}",
               "type": "color"
             },
             "hover": {
-              "value": "{color.green.400}{alpha.hover-full}",
+              "value": "{st.color.bg.secondary.default}{alpha.hover-full}",
               "type": "color"
             }
           },
@@ -2044,11 +2044,11 @@
               "type": "color"
             },
             "active": {
-              "value": "{color.mediatoolBlue.400}",
+              "value": "{st.color.bg.tertiary.default}",
               "type": "color"
             },
             "hover": {
-              "value": "{color.mediatoolBlue.400}{alpha.hover-full}",
+              "value": "{st.color.bg.tertiary.default}{alpha.hover-full}",
               "type": "color"
             }
           },
@@ -2124,15 +2124,15 @@
           },
           "ai": {
             "default": {
-              "value": "{color.teal.400}",
+              "value": "{st.color.ai}",
               "type": "color"
             },
             "active": {
-              "value": "{color.teal.400}",
+              "value": "{st.color.ai}",
               "type": "color"
             },
             "hover": {
-              "value": "{color.teal.400}{alpha.hover-full}",
+              "value": "{st.color.ai}{alpha.hover-full}",
               "type": "color"
             }
           },
@@ -2268,11 +2268,11 @@
               "type": "color"
             },
             "hover": {
-              "value": "{color.blue.600}{alpha.hover-full}",
+              "value": "{st.color.border.brand.default}{alpha.hover-full}",
               "type": "color"
             },
             "active": {
-              "value": "{color.blue.600}",
+              "value": "{st.color.border.brand.default}",
               "type": "color"
             }
           },
@@ -2282,11 +2282,11 @@
               "type": "color"
             },
             "hover": {
-              "value": "{color.green.600}{alpha.hover-full}",
+              "value": "{st.color.border.secondary.default}{alpha.hover-full}",
               "type": "color"
             },
             "active": {
-              "value": "{color.green.600}",
+              "value": "{st.color.border.secondary.default}",
               "type": "color",
               "description": " "
             }
@@ -2297,11 +2297,11 @@
               "type": "color"
             },
             "hover": {
-              "value": "{color.mediatoolBlue.600}{alpha.hover-full}",
+              "value": "{st.color.border.tertiary.default}{alpha.hover-full}",
               "type": "color"
             },
             "active": {
-              "value": "{color.mediatoolBlue.600}",
+              "value": "{st.color.border.tertiary.default}",
               "type": "color"
             }
           },
@@ -2375,7 +2375,7 @@
               "type": "color"
             },
             "tertiary": {
-              "value": "{color.mediatoolBlue.50}",
+              "value": "{color.mono.white}",
               "type": "color"
             },
             "ai": {
@@ -3003,11 +3003,11 @@
               "type": "color"
             },
             "active": {
-              "value": "{color.green.500}",
+              "value": "{st.color.bg.secondary.default}",
               "type": "color"
             },
             "hover": {
-              "value": "{color.green.500}{alpha.hover-full}",
+              "value": "{st.color.bg.secondary.default}{alpha.hover-full}",
               "type": "color"
             }
           },
@@ -3017,11 +3017,11 @@
               "type": "color"
             },
             "hover": {
-              "value": "{color.mediatoolBlue.500}{alpha.hover-full}",
+              "value": "{st.color.bg.tertiary.default}{alpha.hover-full}",
               "type": "color"
             },
             "active": {
-              "value": "{color.mediatoolBlue.500}",
+              "value": "{st.color.bg.tertiary.default}",
               "type": "color"
             }
           },
@@ -3097,15 +3097,15 @@
           },
           "ai": {
             "default": {
-              "value": "{color.teal.500}",
+              "value": "{st.color.ai}",
               "type": "color"
             },
             "active": {
-              "value": "{color.teal.500}",
+              "value": "{st.color.ai}",
               "type": "color"
             },
             "hover": {
-              "value": "{color.teal.500}{alpha.hover-full}",
+              "value": "{st.color.ai}{alpha.hover-full}",
               "type": "color"
             }
           },
@@ -3241,11 +3241,11 @@
               "type": "color"
             },
             "hover": {
-              "value": "{color.blue.400}{alpha.hover-soft}",
+              "value": "{st.color.border.brand.default}{alpha.hover-soft}",
               "type": "color"
             },
             "active": {
-              "value": "{color.blue.400}",
+              "value": "{st.color.border.brand.default}",
               "type": "color"
             }
           },
@@ -3255,11 +3255,11 @@
               "type": "color"
             },
             "hover": {
-              "value": "{color.green.400}{alpha.hover-soft}",
+              "value": "{st.color.border.secondary.default}{alpha.hover-soft}",
               "type": "color"
             },
             "active": {
-              "value": "{color.green.400}",
+              "value": "{st.color.border.secondary.default}",
               "type": "color"
             }
           },
@@ -3269,11 +3269,11 @@
               "type": "color"
             },
             "hover": {
-              "value": "{color.mediatoolBlue.400}{alpha.hover-soft}",
+              "value": "{st.color.border.tertiary.default}{alpha.hover-soft}",
               "type": "color"
             },
             "active": {
-              "value": "{color.mediatoolBlue.400}",
+              "value": "{st.color.border.tertiary.default}",
               "type": "color"
             }
           },
@@ -3975,11 +3975,11 @@
               "type": "color"
             },
             "active": {
-              "value": "{color.coral.300}{alpha.active}",
+              "value": "{st.color.bg.secondary.default}{alpha.active}",
               "type": "color"
             },
             "hover": {
-              "value": "{color.coral.300}{alpha.hover-full}",
+              "value": "{st.color.bg.secondary.default}{alpha.hover-full}",
               "type": "color"
             }
           },
@@ -3989,11 +3989,11 @@
               "type": "color"
             },
             "hover": {
-              "value": "{color.smoke.200}{alpha.hover-full}",
+              "value": "{st.color.bg.tertiary.default}{alpha.hover-full}",
               "type": "color"
             },
             "active": {
-              "value": "{color.smoke.200}{alpha.active}",
+              "value": "{st.color.bg.tertiary.default}{alpha.active}",
               "type": "color"
             }
           },
@@ -4213,11 +4213,11 @@
               "type": "color"
             },
             "hover": {
-              "value": "{color.smoke.200}{alpha.hover-soft}",
+              "value": "{st.color.border.brand.default}{alpha.hover-soft}",
               "type": "color"
             },
             "active": {
-              "value": "{color.smoke.200}",
+              "value": "{st.color.border.brand.default}",
               "type": "color"
             }
           },
@@ -4227,11 +4227,11 @@
               "type": "color"
             },
             "hover": {
-              "value": "{color.coral.300}{alpha.hover-soft}",
+              "value": "{st.color.border.secondary.default}{alpha.hover-soft}",
               "type": "color"
             },
             "active": {
-              "value": "{color.coral.300}",
+              "value": "{st.color.border.secondary.default}",
               "type": "color"
             }
           },
@@ -4241,11 +4241,11 @@
               "type": "color"
             },
             "hover": {
-              "value": "{color.smoke.400}{alpha.hover-soft}",
+              "value": "{st.color.border.tertiary.default}{alpha.hover-soft}",
               "type": "color"
             },
             "active": {
-              "value": "{color.smoke.400}",
+              "value": "{st.color.border.tertiary.default}",
               "type": "color"
             }
           },
@@ -4319,7 +4319,7 @@
               "type": "color"
             },
             "tertiary": {
-              "value": "{color.smoke.800}",
+              "value": "{st.color.inverted-alt}",
               "type": "color"
             },
             "ai": {


### PR DESCRIPTION
This PR adds tokens for the new accent button variant and the sidebar button, fixes text.over-alt tokens applying correct tones depending on semantics. The secondary color token is set to blue.500 instead of green.500. 