### PR TITLE
fix(tokens): accent colors 

### DIFF
--- a/tokens/lib/tokens.json
+++ b/tokens/lib/tokens.json
@@ -5429,8 +5429,20 @@
             "value": "{color.text.inverted}",
             "type": "color"
           },
+          "sidebar": {
+            "value": "{color.text.default}",
+            "type": "color"
+          },
+          "sidebar-active": {
+            "value": "{st.color.text.over.tertiary}",
+            "type": "color"
+          },
           "ai": {
             "value": "{color.text.inverted}",
+            "type": "color"
+          },
+          "accent": {
+            "value": "{st.color.bg.secondary.default}",
             "type": "color"
           }
         },

--- a/tokens/lib/tokens.json
+++ b/tokens/lib/tokens.json
@@ -2030,11 +2030,11 @@
               "type": "color"
             },
             "active": {
-              "value": "{color.green.400}",
+              "value": "{st.color.bg.secondary.default}",
               "type": "color"
             },
             "hover": {
-              "value": "{color.green.400}{alpha.hover-full}",
+              "value": "{st.color.bg.secondary.default}{alpha.hover-full}",
               "type": "color"
             }
           },
@@ -2044,11 +2044,11 @@
               "type": "color"
             },
             "active": {
-              "value": "{color.mediatoolBlue.400}",
+              "value": "{st.color.bg.tertiary.default}",
               "type": "color"
             },
             "hover": {
-              "value": "{color.mediatoolBlue.400}{alpha.hover-full}",
+              "value": "{st.color.bg.tertiary.default}{alpha.hover-full}",
               "type": "color"
             }
           },
@@ -2128,11 +2128,11 @@
               "type": "color"
             },
             "active": {
-              "value": "{color.teal.400}",
+              "value": "{st.color.bg.ai.default}",
               "type": "color"
             },
             "hover": {
-              "value": "{color.teal.400}{alpha.hover-full}",
+              "value": "{st.color.bg.ai.default}{alpha.hover-full}",
               "type": "color"
             }
           },
@@ -2268,11 +2268,11 @@
               "type": "color"
             },
             "hover": {
-              "value": "{color.blue.600}{alpha.hover-full}",
+              "value": "{st.color.border.brand.default}{alpha.hover-full}",
               "type": "color"
             },
             "active": {
-              "value": "{color.blue.600}",
+              "value": "{st.color.border.brand.default}",
               "type": "color"
             }
           },
@@ -2282,11 +2282,11 @@
               "type": "color"
             },
             "hover": {
-              "value": "{color.green.600}{alpha.hover-full}",
+              "value": "{st.color.border.secondary.default}{alpha.hover-full}",
               "type": "color"
             },
             "active": {
-              "value": "{color.green.600}",
+              "value": "{st.color.border.secondary.default}",
               "type": "color",
               "description": " "
             }
@@ -2297,11 +2297,11 @@
               "type": "color"
             },
             "hover": {
-              "value": "{color.mediatoolBlue.600}{alpha.hover-full}",
+              "value": "{st.color.border.tertiary.default}{alpha.hover-full}",
               "type": "color"
             },
             "active": {
-              "value": "{color.mediatoolBlue.600}",
+              "value": "{st.color.border.tertiary.default}",
               "type": "color"
             }
           },
@@ -2999,15 +2999,15 @@
           },
           "secondary": {
             "default": {
-              "value": "{color.green.500}",
+              "value": "{color.blue.500}",
               "type": "color"
             },
             "active": {
-              "value": "{color.green.500}",
+              "value": "{st.color.bg.secondary.default}",
               "type": "color"
             },
             "hover": {
-              "value": "{color.green.500}{alpha.hover-full}",
+              "value": "{st.color.bg.secondary.default}{alpha.hover-full}",
               "type": "color"
             }
           },
@@ -3017,11 +3017,11 @@
               "type": "color"
             },
             "hover": {
-              "value": "{color.mediatoolBlue.500}{alpha.hover-full}",
+              "value": "{st.color.bg.tertiary.default}{alpha.hover-full}",
               "type": "color"
             },
             "active": {
-              "value": "{color.mediatoolBlue.500}",
+              "value": "{st.color.bg.tertiary.default}",
               "type": "color"
             }
           },
@@ -3101,11 +3101,11 @@
               "type": "color"
             },
             "active": {
-              "value": "{color.teal.500}",
+              "value": "{st.color.bg.ai.default}",
               "type": "color"
             },
             "hover": {
-              "value": "{color.teal.500}{alpha.hover-full}",
+              "value": "{st.color.bg.ai.default}{alpha.hover-full}",
               "type": "color"
             }
           },
@@ -3241,25 +3241,25 @@
               "type": "color"
             },
             "hover": {
-              "value": "{color.blue.400}{alpha.hover-soft}",
+              "value": "{st.color.border.brand.default}{alpha.hover-soft}",
               "type": "color"
             },
             "active": {
-              "value": "{color.blue.400}",
+              "value": "{st.color.border.brand.default}",
               "type": "color"
             }
           },
           "secondary": {
             "default": {
-              "value": "{color.green.400}",
+              "value": "{color.blue.400}",
               "type": "color"
             },
             "hover": {
-              "value": "{color.green.400}{alpha.hover-soft}",
+              "value": "{st.color.border.secondary.default}{alpha.hover-soft}",
               "type": "color"
             },
             "active": {
-              "value": "{color.green.400}",
+              "value": "{st.color.border.secondary.default}",
               "type": "color"
             }
           },
@@ -3269,11 +3269,11 @@
               "type": "color"
             },
             "hover": {
-              "value": "{color.mediatoolBlue.400}{alpha.hover-soft}",
+              "value": "{st.color.border.tertiary.default}{alpha.hover-soft}",
               "type": "color"
             },
             "active": {
-              "value": "{color.mediatoolBlue.400}",
+              "value": "{st.color.border.tertiary.default}",
               "type": "color"
             }
           },
@@ -3975,11 +3975,11 @@
               "type": "color"
             },
             "active": {
-              "value": "{color.coral.300}{alpha.active}",
+              "value": "{st.color.bg.secondary.default}{alpha.active}",
               "type": "color"
             },
             "hover": {
-              "value": "{color.coral.300}{alpha.hover-full}",
+              "value": "{st.color.bg.secondary.default}{alpha.hover-full}",
               "type": "color"
             }
           },
@@ -3989,11 +3989,11 @@
               "type": "color"
             },
             "hover": {
-              "value": "{color.smoke.200}{alpha.hover-full}",
+              "value": "{st.color.bg.tertiary.default}{alpha.hover-full}",
               "type": "color"
             },
             "active": {
-              "value": "{color.smoke.200}{alpha.active}",
+              "value": "{st.color.bg.tertiary.default}{alpha.active}",
               "type": "color"
             }
           },
@@ -4213,11 +4213,11 @@
               "type": "color"
             },
             "hover": {
-              "value": "{color.smoke.200}{alpha.hover-soft}",
+              "value": "{st.color.border.brand.default}{alpha.hover-soft}",
               "type": "color"
             },
             "active": {
-              "value": "{color.smoke.200}",
+              "value": "{st.color.border.brand.default}",
               "type": "color"
             }
           },
@@ -4227,11 +4227,11 @@
               "type": "color"
             },
             "hover": {
-              "value": "{color.coral.300}{alpha.hover-soft}",
+              "value": "{st.color.border.secondary.default}{alpha.hover-soft}",
               "type": "color"
             },
             "active": {
-              "value": "{color.coral.300}",
+              "value": "{st.color.border.secondary.default}",
               "type": "color"
             }
           },
@@ -4241,11 +4241,11 @@
               "type": "color"
             },
             "hover": {
-              "value": "{color.smoke.400}{alpha.hover-soft}",
+              "value": "{st.color.border.tertiary.default}{alpha.hover-soft}",
               "type": "color"
             },
             "active": {
-              "value": "{color.smoke.400}",
+              "value": "{st.color.border.tertiary.default}",
               "type": "color"
             }
           },
@@ -4295,19 +4295,19 @@
         "text": {
           "over": {
             "success": {
-              "value": "{color.green.800}",
+              "value": "{color.moss.800}",
               "type": "color"
             },
             "error": {
-              "value": "{color.rose.700}",
+              "value": "{color.red.800}",
               "type": "color"
             },
             "warning": {
-              "value": "{color.coral.700}",
+              "value": "{color.coral.800}",
               "type": "color"
             },
             "info": {
-              "value": "{color.smoke.900}",
+              "value": "{color.coral.800}",
               "type": "color"
             },
             "brand": {
@@ -4315,7 +4315,7 @@
               "type": "color"
             },
             "secondary": {
-              "value": "{color.coral.700}",
+              "value": "{color.coral.800}",
               "type": "color"
             },
             "tertiary": {
@@ -4323,7 +4323,7 @@
               "type": "color"
             },
             "ai": {
-              "value": "{st.color.brand}",
+              "value": "{color.moss.800}",
               "type": "color"
             }
           },
@@ -4343,7 +4343,7 @@
               "type": "color"
             },
             "danger": {
-              "value": "{st.color.destructive}",
+              "value": "{color.red.600}",
               "type": "color"
             },
             "success": {
@@ -4351,7 +4351,7 @@
               "type": "color"
             },
             "ai": {
-              "value": "{color.coral.500}",
+              "value": "{color.moss.600}",
               "type": "color"
             }
           },

--- a/tokens/lib/tokens.json
+++ b/tokens/lib/tokens.json
@@ -3347,7 +3347,7 @@
               "type": "color"
             },
             "tertiary": {
-              "value": "{color.mediatoolBlue.800}",
+              "value": "{color.mono.white}",
               "type": "color"
             },
             "ai": {
@@ -4311,7 +4311,7 @@
               "type": "color"
             },
             "brand": {
-              "value": "{st.color.brand}",
+              "value": "{color.inkBlue.800}",
               "type": "color"
             },
             "secondary": {


### PR DESCRIPTION
This PR adds tokens for the new accent button variant and the sidebar button, fixes text.over-alt tokens applying correct tones depending on semantics. The bg.secondary.default color token is set to blue.500 instead of green.500, border.secondary.default - to blue.400 instead of green.400.