### PR TITLE
feat(framework): add setIsOpen prop to DateRangePicker

### DIFF
--- a/framework/lib/components/date-picker/date-picker/date-range-picker.tsx
+++ b/framework/lib/components/date-picker/date-picker/date-range-picker.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React, { useEffect, useRef } from 'react'
 import { FocusScope } from '@react-aria/focus'
 import { useDateRangePickerState } from '@react-stately/datepicker'
 import { useDateRangePicker } from '@react-aria/datepicker'
@@ -103,6 +103,7 @@ export const DateRangePicker = (props: DateRangePickerProps) => {
     firstDayOfWeek,
     onSave,
     buttonLabel = 'Save',
+    setIsOpen = () => {},
   } = props
   const ref = useRef() as React.MutableRefObject<HTMLInputElement>
   const { group } = useMultiStyleConfig('DatePicker')
@@ -123,6 +124,10 @@ export const DateRangePicker = (props: DateRangePickerProps) => {
     shouldCloseOnSelect: false,
     hideTimeZone: true,
   })
+
+  useEffect(() => {
+    setIsOpen(state.isOpen)
+  }, [ state.isOpen ])
 
   const {
     groupProps,

--- a/framework/lib/components/date-picker/types.ts
+++ b/framework/lib/components/date-picker/types.ts
@@ -43,6 +43,7 @@ export interface DateRangePickerProps
   fiscalStartDay?: number
   renderInPortal?: boolean
   buttonLabel?: string
+  setIsOpen?: (isOpen: boolean) => void
 }
 
 export interface DatePickerFieldProps


### PR DESCRIPTION
Adds setIsOpen prop to date range picker to inform the parent component of the open state of the picker modal.