### PR TITLE
fix(framework): add null check to savedDateRange and defaultDateRange

### DIFF
--- a/framework/lib/components/date-picker/components/calendar/range-calendar.tsx
+++ b/framework/lib/components/date-picker/components/calendar/range-calendar.tsx
@@ -36,7 +36,6 @@ export const RangeCalendar = (props: RangeCalendarProps) => {
     onSave,
     buttonLabel = 'Save',
     clearButtonLabel = 'Clear',
-    onCancel,
   } = props
 
   const { locale } = useLocale()
@@ -73,15 +72,6 @@ export const RangeCalendar = (props: RangeCalendarProps) => {
     createCalendar: () => new GregorianCalendar(),
   })
 
-  const handleOnReset = () => {
-    if (onCancel) {
-      onCancel()
-    } else {
-      resetDate()
-    }
-    handleClose()
-  }
-
   const focusDateRange = (dateRange: DateRangeValue) => {
     if (dateRange && dateRange.start && dateRange.end) {
       calendarOneState.setFocusedDate(dateRange.start as CalendarDate)
@@ -102,6 +92,11 @@ export const RangeCalendar = (props: RangeCalendarProps) => {
 
   const handleSave = () => {
     onSave?.()
+    handleClose()
+  }
+
+  const handleReset = () => {
+    resetDate()
     handleClose()
   }
 
@@ -140,7 +135,7 @@ export const RangeCalendar = (props: RangeCalendarProps) => {
                 </Stack>
                 <HStack pt="2" alignSelf="end">
                   { isClearable && (
-                    <Button onClick={ handleOnReset } variant="ghost" size="sm">
+                    <Button onClick={ handleReset } variant="ghost" size="sm">
                       { clearButtonLabel }
                     </Button>
                   ) }

--- a/framework/lib/components/date-picker/components/calendar/types.ts
+++ b/framework/lib/components/date-picker/components/calendar/types.ts
@@ -11,7 +11,6 @@ export interface RangeCalendarProps extends AriaRangeCalendarProps<DateValue> {
   firstDayOfWeek: FirstDayOfWeek
   onSave?: () => void
   buttonLabel?: string
-  onCancel?: () => void
   clearButtonLabel?: string
 }
 

--- a/framework/lib/components/date-picker/types.ts
+++ b/framework/lib/components/date-picker/types.ts
@@ -34,7 +34,14 @@ export interface DatePickerProps
 export interface DateRangePickerProps
   extends Omit<AriaDateRangePickerProps<DateValue>, 'firstDayOfWeek' | 'onChange' | 'value' | 'minValue' | 'maxValue'>,
   DatePickerSettings {
+  /**
+   * Function to be called when the user changes the date, both in
+   * the modal and the input field.
+   */
   onChange?: (date: null | DateRange) => void
+  /**
+   * Function to be called when the user saves the date change.
+   */
   onSave?: () => void
   value: DateRange | null
   minValue?: string | undefined
@@ -42,12 +49,36 @@ export interface DateRangePickerProps
   fiscalStartMonth?: number
   fiscalStartDay?: number
   renderInPortal?: boolean
+  /**
+   * Label for the save button in the date range picker modal
+   */
   buttonLabel?: string
-  setIsOpen?: (isOpen: boolean) => void
+  /**
+   * The previously saved date range used for save/cancel functionality.
+   * When provided along with defaultDateRange, enables save and cancel buttons that appear
+   * when the current value differs from the saved value. The component will revert to this
+   * value when the popover is closed without saving or when cancel is clicked.
+   */
   savedDateRange?: DateRange | null
+  /**
+   * The default date range to set when the input is cleared.
+   * When provided, the clear button will be shown next to the input field when
+   * modal is closed if the current value differs from the default value.
+   * If not provided, the clear button will always be shown when modal is closed.
+   */
   defaultDateRange?: DateRange | null
+  /**
+   * Custom reset button to be shown next to the input field when modal is closed.
+   * If not provided, the default clear button will be shown.
+   */
   CustomResetButton?: React.ReactNode
+  /**
+   * Custom label for the clear button in the date range picker modal
+   */
   clearButtonLabel?: string
+  /**
+   * Function to be called when the user cancels the date change
+   */
   onCancelChanges?: () => void
 }
 


### PR DESCRIPTION
Adds null check to savedDateRange and defaultDateRange. previously they were set to value. This lead to the reset button never showing up if defaultdaterange was not provided.