### PR TITLE
fix(framework): refactor combo picker

### DIFF
--- a/framework/lib/components/combo-picker/combo-picker-field.tsx
+++ b/framework/lib/components/combo-picker/combo-picker-field.tsx
@@ -82,7 +82,7 @@ export const ComboPickerField = ({
     isRequired={ isRequired }
     validate={ validate }
   >
-    { ({ value, onChange }) => (
+    { ({ onChange }) => (
       <ComboPicker
         data-testid="combo-picker-test-id"
         aria-label={ label }
@@ -90,7 +90,6 @@ export const ComboPickerField = ({
           onChange(comboPickerValue)
           onChangeCallback?.(comboPickerValue)
         } }
-        value={ value }
         { ...rest }
       />
     ) }

--- a/framework/lib/components/combo-picker/combo-picker.tsx
+++ b/framework/lib/components/combo-picker/combo-picker.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { Button, InputRightElement, useDisclosure } from '@chakra-ui/react'
-import { is } from 'ramda'
-import { ComboPickerOption, ComboPickerProps, ComboPickerValue } from './types'
+import { Button, InputGroup, InputRightElement, useDisclosure } from '@chakra-ui/react'
+import { ComboPickerOption, ComboPickerProps } from './types'
 import { Select, SingleValue } from '../select'
 import { Box } from '../box'
 import { FormattedNumberInput } from '../text-field'
@@ -20,30 +19,19 @@ export const ComboPicker = ({
   formatPreset,
   isDisabled,
   isReadOnly,
-  defaultToZeroIfEmpty = true,
   max = Infinity,
   min = -Infinity,
   ...rest
 }: ComboPickerProps) => {
   const { isOpen, onToggle, onClose } = useDisclosure()
-  const [ inputValue, setInputValue ] = useState(valueProp?.input)
-  const [ selectOption, setSelectOption ] = useState(valueProp?.option)
+  const { input: inputValue, option: selectOption } = valueProp
   const [ enableSelectInput, setEnableSelectInput ] = useState(false)
 
   const buttonRef = useRef<any>()
   const selectRef = useRef<any>()
 
-  const getNewValue = (option?: ComboPickerOption, input?: number): ComboPickerValue => {
-    const newValueOption = option ?? options[0]
-
-    return (is(Number, input))
-      ? { input: Number(input), option: newValueOption }
-      : { option: newValueOption }
-  }
-
   const handleInputChange = (newInputvalue?: number) => {
-    const newValue = getNewValue(valueProp?.option, newInputvalue)
-
+    const newValue = { ...valueProp, input: newInputvalue }
     onChange?.(newValue)
   }
 
@@ -58,7 +46,8 @@ export const ComboPicker = ({
 
   const handleSelectChange = (selectedOption: SingleValue<ComboPickerOption>) => {
     if (selectedOption) {
-      onChange?.(getNewValue(selectedOption, valueProp?.input))
+      const newValue = { ...valueProp, option: selectedOption }
+      onChange?.(newValue)
 
       if (isOpen) {
         handleSelectClose()
@@ -80,20 +69,10 @@ export const ComboPicker = ({
     }
   }, [ enableSelectInput ])
 
-  useEffect(() => {
-    const option = valueProp?.option ?? options[0]
-    const input = defaultToZeroIfEmpty ? valueProp?.input ?? 0 : valueProp?.input
-
-    setSelectOption(option)
-    setInputValue(input)
-
-    onChange?.(getNewValue(option, input))
-  }, [ valueProp?.input, valueProp?.option, defaultToZeroIfEmpty, options ])
-
   const buttonWidth = (buttonRef.current?.offsetWidth ?? 0)
 
   return (
-    <>
+    <InputGroup>
       <FormattedNumberInput
         width="100%"
         onChange={ (values) => handleInputChange(values.floatValue) }
@@ -160,6 +139,6 @@ export const ComboPicker = ({
           </Box>
         )
       }
-    </>
+    </InputGroup>
   )
 }

--- a/framework/lib/components/combo-picker/types.ts
+++ b/framework/lib/components/combo-picker/types.ts
@@ -14,14 +14,13 @@ export type ComboPickerOption = {
 
 export interface ComboPickerProps extends Omit<FormattedNumberInputProps, | 'value' | 'onChange'> {
   options: ComboPickerOption[]
-  value?: ComboPickerValue
+  value: ComboPickerValue
   onChange?: (value: ComboPickerValue) => void
   defaultOption?: ComboPickerOption
   precision?: number
   formatPreset?: FormattedNumberInputPreset
   isDisabled?: boolean
   isReadOnly?: boolean
-  defaultToZeroIfEmpty?: boolean
 }
 
 export interface ComboPickerFieldProps extends ComboPickerProps {


### PR DESCRIPTION
Remove unnecessary state and useEffect from combo picker. This is making combo pickers behaviour more predictable, and state is expected to be handled outside of the component. Updated on sub components change handlers to only operate on the value they are changing.