### PR TITLE
fix(northlight): docs page scroll

### DIFF
--- a/docs/src/app/components/page.tsx
+++ b/docs/src/app/components/page.tsx
@@ -14,10 +14,8 @@ export const Page = ({
 }: Props) => (
   <Box
     w="100%"
-    h="100%"
+    minH="100%"
     p={ 6 }
-    overflowY="auto"
-    overscrollBehavior="contain"
     bgColor="background.default"
     color="text.default"
   >
@@ -27,7 +25,7 @@ export const Page = ({
         <Heading as="h2" size="sm">{ subtitle }</Heading>
       ) : subtitle }
     </Stack>
-    <Box width="100%" mt={ 10 } overflowY="auto">
+    <Box width="100%" mt={ 10 }>
       { children }
     </Box>
   </Box>

--- a/docs/src/reference/reference-page/reference-page-wrapper.tsx
+++ b/docs/src/reference/reference-page/reference-page-wrapper.tsx
@@ -32,9 +32,7 @@ export const Page = ({
   references,
 }: Props) => (
   <Stack
-    h="100%"
-    overflowY="auto"
-    overscrollBehavior="contain"
+    minH="100%"
     bgColor="background.default"
     color="text.default"
     pb="10rem"
@@ -80,7 +78,7 @@ export const Page = ({
       </Stack>
 
     </VStack>
-    <VStack width="100%" mt={ 10 } overflowY="scroll">
+    <VStack width="100%" mt={ 10 }>
       { children }
     </VStack>
   </Stack>

--- a/docs/src/reference/reference-page/side-nav-bar.tsx
+++ b/docs/src/reference/reference-page/side-nav-bar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Capitalized, Stack } from '@northlight/ui'
+import { Box, Capitalized, Stack } from '@northlight/ui'
 import { NavSideLink } from '../../app/components/nav-side-link'
 
 interface SideNavBarProps {
@@ -33,15 +33,17 @@ export const SideNavBar = ({
   }, [])
 
   return (
-    <Stack w="28rem" position="fixed" h="full" right="0" top="100px" pt="8">
-      <Capitalized>On this page</Capitalized>
+    <Stack w="28rem" position="fixed" right="0" top="100px" pt="8" pointerEvents="none">
+      <Capitalized pointerEvents="auto">On this page</Capitalized>
       { links.map((link, i) => (
-        <NavSideLink
-          linkName={ link }
-          linkProps={ { href: `/reference/${componentName}#Example-${i}` } }
-          isActive={ activeSection === i }
-          onClick={ () => setActiveSection(i) }
-        />
+        <Box key={ link } pointerEvents="auto">
+          <NavSideLink
+            linkName={ link }
+            linkProps={ { href: `/reference/${componentName}#Example-${i}` } }
+            isActive={ activeSection === i }
+            onClick={ () => setActiveSection(i) }
+          />
+        </Box>
       )) }
     </Stack>
   )


### PR DESCRIPTION
Turns out the Page wrappers were basically hijacking scroll. We had `h="100%"` combined with `overflowY="auto"` and `overscrollBehavior="contain"`, which created these isolated scroll containers. Since the global theme already forces body and #app to be 100% height, everything ended up locked to the viewport. On top of that, `overscrollBehavior: contain` made sure scroll events never bubbled up to the window. So yeah, scrolling got stuck.

What I changed:

`reference-page-wrapper.tsx`
Switched `h="100%`" to `minH="100%"` and removed the `overflow` + `overscroll` props from the outer container. Also removed `overflowY="scroll"` from the inner one. Now the content just behaves normally and scrolls with the page.

`page.tsx`
Same cleanup here. Replaced `h="100%"` with `minH="100%"` and removed the `overflow/overscroll` combo from both containers.

`side-nav-bar.tsx`
Dropped` h="full"` since it wasn’t really needed. Also added `pointerEvents="none"` to the fixed container so it stops blocking scroll on the right side. Wrapped links with `pointerEvents="auto"` so they still work.


Thank me later.

**Before:**

https://github.com/user-attachments/assets/bca29ee5-548d-4605-82cb-b65409f66b68

**After:**

https://github.com/user-attachments/assets/c278c727-b28e-4f4a-8706-b41174738643

