### PR TITLE
feat(northlight): DateRangePicker sizes

### DIFF
--- a/framework/lib/components/date-picker/components/date-field/date-field.tsx
+++ b/framework/lib/components/date-picker/components/date-field/date-field.tsx
@@ -11,8 +11,9 @@ import { delimeterIncluded, formatQuery } from './utils'
 
 export const DateField = (props: DateFieldProps) => {
   const ref = useRef<HTMLInputElement>(null)
+  const { size, dateFormat = 'dd/mm/yyyy', ...ariaProps } = props
   const state = useDateFieldState({
-    ...props,
+    ...ariaProps,
     /* Hard coding the United Kingdom locale,
      this enforces using english characters e.g.
       yyyy and not other such as åååå or chinese, which prevents hard to predict bugs */
@@ -20,11 +21,10 @@ export const DateField = (props: DateFieldProps) => {
     createCalendar,
   })
 
-  const { dateField } = useMultiStyleConfig('DatePicker')
-  const { fieldProps } = useDateField(props, state, ref)
+  const { dateField } = useMultiStyleConfig('DatePicker', { size })
+  const { fieldProps } = useDateField(ariaProps, state, ref)
 
   const { segments } = state
-  const { dateFormat = 'dd/mm/yyyy' } = props
   const getMatchingSegment = (query: string, index: number) =>
     find(
       (segment: DateSegmentType) => segment.placeholder === formatQuery(query)
@@ -44,7 +44,7 @@ export const DateField = (props: DateFieldProps) => {
     >
       { sortedSegments.map((segment, i) => {
         const id = `${segment.type}-${i}`
-        return <DateSegment segment={ segment } state={ state } key={ id } />
+        return <DateSegment segment={ segment } state={ state } key={ id } size={ size } />
       }) }
     </Box>
   )

--- a/framework/lib/components/date-picker/components/date-field/date-segment.tsx
+++ b/framework/lib/components/date-picker/components/date-field/date-segment.tsx
@@ -4,12 +4,12 @@ import { useDateSegment } from '@react-aria/datepicker'
 import { Box } from '../../../box'
 import { DateSegmentProps } from './types'
 
-export const DateSegment = ({ segment, state }: DateSegmentProps) => {
+export const DateSegment = ({ segment, state, size }: DateSegmentProps) => {
   const ref = useRef<HTMLInputElement>(null)
   const { segmentProps } = useDateSegment(segment, state, ref)
 
   const isDivider = segment.type === 'literal'
-  const { dateSegment } = useMultiStyleConfig('DatePicker')
+  const { dateSegment } = useMultiStyleConfig('DatePicker', { size })
   const minWidth = `${String(segment.maxValue).length}ch`
 
   return (
@@ -26,7 +26,6 @@ export const DateSegment = ({ segment, state }: DateSegmentProps) => {
             ? 'text.subduded'
             : 'text.default'
       }
-      fontSize="md"
     >
       { segment.text }
     </Box>

--- a/framework/lib/components/date-picker/components/date-field/styled-field.tsx
+++ b/framework/lib/components/date-picker/components/date-field/styled-field.tsx
@@ -4,10 +4,10 @@ import { Box } from '../../../box'
 import { StyledFieldProps } from './types'
 
 export const StyledField = forwardRef((
-  { isInvalid, isDisabled, children, variant, ...rest }: StyledFieldProps,
+  { isInvalid, isDisabled, children, variant, size, ...rest }: StyledFieldProps,
   ref: any
 ) => {
-  const { styledField } = useMultiStyleConfig('DatePicker', { variant })
+  const { styledField } = useMultiStyleConfig('DatePicker', { variant, size })
 
   return (
     <Box
@@ -17,7 +17,6 @@ export const StyledField = forwardRef((
       aria-disabled={ isDisabled }
       display="flex"
       alignItems="center"
-      h={ 10 }
       __css={ styledField }
     >
       { children }

--- a/framework/lib/components/date-picker/components/date-field/trigger.tsx
+++ b/framework/lib/components/date-picker/components/date-field/trigger.tsx
@@ -4,6 +4,24 @@ import { Button } from '../../../button'
 import { TriggerProps } from './types'
 import { Icon } from '../../../icon'
 
+const sizeToButtonSize = {
+  sm: 'xs',
+  md: 'sm',
+  lg: 'md',
+} as const
+
+const sizeToBoxSize = {
+  sm: 6,
+  md: 8,
+  lg: 10,
+}
+
+const sizeToIconBoxSize = {
+  sm: 3,
+  md: 4,
+  lg: 5,
+}
+
 export const Trigger = (props: TriggerProps) => {
   const {
     id,
@@ -14,6 +32,7 @@ export const Trigger = (props: TriggerProps) => {
     'aria-expanded': ariaExpanded,
     isDisabled,
     handleClick,
+    size = 'md',
   } = props
   const ref = useRef<HTMLButtonElement>(null)
 
@@ -33,15 +52,21 @@ export const Trigger = (props: TriggerProps) => {
       aria-labelledby={ ariaLabelledBy }
       aria-describedby={ ariaDescribedBy }
       aria-expanded={ ariaExpanded }
-      size="sm"
-      boxSize={ 8 }
+      size={ sizeToButtonSize[size] }
+      boxSize={ sizeToBoxSize[size] }
       variant="ghost"
       isDisabled={ isDisabled }
       onClick={ handleClick }
       onKeyDown={ handleKeyDown }
       pointerEvents={ isDisabled ? 'none' : 'auto' }
     >
-      <Icon as={ CalendarDuo } />
+      <Icon
+        as={ CalendarDuo }
+        sx={ {
+          boxSize: sizeToIconBoxSize[size],
+          '& path': { vectorEffect: 'non-scaling-stroke' },
+        } }
+      />
     </Button>
   )
 }

--- a/framework/lib/components/date-picker/components/date-field/types.ts
+++ b/framework/lib/components/date-picker/components/date-field/types.ts
@@ -7,11 +7,13 @@ import { AriaButtonProps } from '@react-aria/button'
 export type DateSegmentType = DateSegment
 export interface DateFieldProps extends AriaDateFieldProps<DateValue> {
   dateFormat?: string
+  size?: 'sm' | 'md' | 'lg'
 }
 
 export interface DateSegmentProps {
   segment: DateSegment
   state: DateFieldState
+  size?: 'sm' | 'md' | 'lg'
 }
 
 export interface StyledFieldProps extends HTMLAttributes<HTMLElement> {
@@ -19,8 +21,10 @@ export interface StyledFieldProps extends HTMLAttributes<HTMLElement> {
   isDisabled?: boolean
   children: ReactNode
   variant?: 'outline' | 'filled'
+  size?: 'sm' | 'md' | 'lg'
 }
 
 export interface TriggerProps extends AriaButtonProps {
   handleClick: () => void
+  size?: 'sm' | 'md' | 'lg'
 }

--- a/framework/lib/components/date-picker/date-picker/date-range-picker.tsx
+++ b/framework/lib/components/date-picker/date-picker/date-range-picker.tsx
@@ -122,6 +122,7 @@ export const DateRangePicker = (props: DateRangePickerProps) => {
     allowsNonContiguousRanges,
     startName,
     endName,
+    size = 'md',
   } = props
   const ref = useRef() as React.MutableRefObject<HTMLInputElement>
   const dialogRef = useRef() as React.MutableRefObject<HTMLDivElement>
@@ -363,6 +364,7 @@ export const DateRangePicker = (props: DateRangePickerProps) => {
               isDisabled={ isDisabled }
               isInvalid={ isInvalid }
               variant={ variant }
+              size={ size }
             >
               <HStack paddingInlineStart="1a" data-testid="daterange-picker-input-field" paddingInlineEnd={ 10 }>
                 <DateField
@@ -386,6 +388,7 @@ export const DateRangePicker = (props: DateRangePickerProps) => {
                   autoFocus={ startFieldAutoFocus }
                   name={ startFieldName }
                   dateFormat={ dateFormat }
+                  size={ size }
                 />
                 <P>-</P>
                 <DateField
@@ -408,6 +411,7 @@ export const DateRangePicker = (props: DateRangePickerProps) => {
                   isInvalid={ endFieldIsInvalid }
                   name={ endFieldName }
                   dateFormat={ dateFormat }
+                  size={ size }
                 />
               </HStack>
             </StyledField>
@@ -421,6 +425,7 @@ export const DateRangePicker = (props: DateRangePickerProps) => {
                 aria-expanded={ buttonAriaExpanded }
                 isDisabled={ isDisabled }
                 handleClick={ togglePopup }
+                size={ size }
               />
             </InputRightElement>
           </InputGroup>

--- a/framework/lib/components/date-picker/types.ts
+++ b/framework/lib/components/date-picker/types.ts
@@ -36,6 +36,7 @@ export interface DatePickerProps
 export interface DateRangePickerProps
   extends Omit<AriaDateRangePickerProps<DateValue>, 'firstDayOfWeek' | 'onChange' | 'value' | 'minValue' | 'maxValue'>,
   DatePickerSettings {
+  size?: 'sm' | 'md' | 'lg'
   /**
    * Function to be called when the user changes the date, both in
    * the modal and the input field.
@@ -102,9 +103,10 @@ export interface DatePickerFieldProps
   fiscalStartDay?: number
 }
 
-export interface DateRangePickerFieldProps extends Omit<DatePickerFieldProps, 'onChange'> {
+export interface DateRangePickerFieldProps extends Omit<DatePickerFieldProps, 'onChange' | 'size'> {
   onChange?: (date: null | DateRange) => void
   buttonLabel?: string
+  size?: 'sm' | 'md' | 'lg'
 }
 
 export type FormBody = Record<string, DateRange>

--- a/framework/lib/theme/components/date-picker/index.ts
+++ b/framework/lib/theme/components/date-picker/index.ts
@@ -67,4 +67,21 @@ export const DatePicker: ComponentMultiStyleConfig = {
       },
     }),
   },
+  sizes: {
+    sm: {
+      styledField: { h: 8 },
+      dateSegment: { fontSize: 'sm' },
+    },
+    md: {
+      styledField: { h: 10 },
+      dateSegment: { fontSize: 'md' },
+    },
+    lg: {
+      styledField: { h: 12 },
+      dateSegment: { fontSize: 'xl' },
+    },
+  },
+  defaultProps: {
+    size: 'md',
+  },
 }

--- a/framework/test/unit/components/avatar/avatar-test.tsx
+++ b/framework/test/unit/components/avatar/avatar-test.tsx
@@ -68,17 +68,11 @@ const users: Record<string, User> = {
 
 const { isOk } = assert
 
-const getAvatar = (customProps = { }) => {
-  const props = {
-    ...customProps,
-  }
-  return (
-    <Avatar { ...props } />
-  )
-}
+const getAvatar = (customProps: { name?: string, image?: string } = { }) => (
+  <Avatar { ...customProps } />
+)
 
-const getComponent = (name?: string) =>
-  screen.getByTestId(`avatar-${name}`).children[0]
+const getComponent = (name?: string) => screen.getByTestId(`avatar-${name}`).children[0]
 
 describe('Avatar', () => {
   it('Renders properly', () => {


### PR DESCRIPTION
Adds a size prop to the DateRangePicker according to the Figma sketches.

Figma sketches:
<img width="508" height="259" alt="Screenshot 2026-05-15 at 15 45 45" src="https://github.com/user-attachments/assets/00127fd8-91e6-4510-bf02-a7e18d6c8686" />

Actual result:

https://github.com/user-attachments/assets/7df26ef1-ccd5-42c0-bea5-f90c11629281

