### PR TITLE
fix(select): make Select types bundler/TS7-safe

### DIFF
--- a/framework/lib/components/createable-select-dropdown/types.ts
+++ b/framework/lib/components/createable-select-dropdown/types.ts
@@ -1,7 +1,7 @@
-import { Variant } from 'chakra-react-select/dist/types/types'
 import { ComponentProps } from 'react'
-import { CreatableSelectComponent } from 'chakra-react-select'
+import { CreatableSelectComponent, GroupBase } from 'chakra-react-select'
 import { Option } from '../select'
+import { ChakraReactSelectExtraProps, SelectVariant } from '../../types'
 
 export interface CreationOption <T extends string = string> extends Option<T> {
   isCreation: boolean
@@ -10,7 +10,8 @@ export interface CreationOption <T extends string = string> extends Option<T> {
 export type CreationOptionValue = 'add_field'
 
 export interface CreatableSelectDropdownProps<T extends string = string>
-  extends ComponentProps<CreatableSelectComponent> {
+  extends ComponentProps<CreatableSelectComponent>,
+  ChakraReactSelectExtraProps<unknown, boolean, GroupBase<unknown>> {
   /**
    * An array of "Option" objects that represents the initial options available in the dropdown.
    * Each "Option" object must have a "label" and a "value" property (both strings).
@@ -55,7 +56,7 @@ export interface CreatableSelectDropdownProps<T extends string = string>
    * The default value is 'outline'.
    *
   */
-  variant?: Variant
+  variant?: SelectVariant
 
   /**
    * Value of the initially selected option.

--- a/framework/lib/components/search-bar/types.ts
+++ b/framework/lib/components/search-bar/types.ts
@@ -7,7 +7,7 @@ import {
   GroupBase,
 } from 'chakra-react-select'
 import { RegisterOptions } from 'react-hook-form'
-import { InputFieldProps } from '../../types'
+import { ChakraReactSelectExtraProps, InputFieldProps } from '../../types'
 
 type Size = 'sm' | 'md' | 'lg'
 export interface SearchBarOptionType {
@@ -23,7 +23,8 @@ export interface SearchBarProps<T extends SearchBarOptionType, K extends boolean
   extends Omit<
   ChakraReactSelectProps<T, boolean, GroupBase<T>>,
   'onChange' | 'value'
-  > {
+  >,
+  ChakraReactSelectExtraProps<T, boolean, GroupBase<T>> {
   value?: T | T[]
   onChange?: (val: any, event: ActionMeta<T>) => void
   onAdd?: (val: unknown) => void

--- a/framework/lib/components/select/types.ts
+++ b/framework/lib/components/select/types.ts
@@ -10,7 +10,7 @@ import {
 import { Icon, StackDirection } from '@chakra-ui/react'
 import { ComponentProps, ComponentType, Ref } from 'react'
 import { RegisterOptions } from 'react-hook-form'
-import { InputFieldProps } from '../../types'
+import { ChakraReactSelectExtraProps, InputFieldProps } from '../../types'
 
 export type { SingleValue, MultiValue } from 'chakra-react-select'
 
@@ -26,7 +26,8 @@ export interface SelectProps<T, K extends boolean>
   extends Omit<
   ChakraReactSelectProps<T, K, GroupBase<T>>,
   'onChange' | 'value' | 'isMulti'
-  > {
+  >,
+  ChakraReactSelectExtraProps<T, K, GroupBase<T>> {
   /** Whatever is currently selected by the select will be controlled by value prop, if value is
    *  of type string then it will automatically pair it up with matching object from options list */
   value?: K extends true ? T[] | string[] : T | string | null

--- a/framework/lib/types/chakra-react-select/index.ts
+++ b/framework/lib/types/chakra-react-select/index.ts
@@ -1,0 +1,74 @@
+import type {
+  ChakraStylesConfig,
+  GroupBase,
+  SelectedOptionStyle,
+  TagVariant,
+} from 'chakra-react-select'
+
+/**
+ * The `variant` value forwarded to the underlying chakra `Input`/`Select`.
+ *
+ * Mirrors `chakra-react-select`'s internal `Variant` type, redeclared here so
+ * `@northlight/ui` does not depend on the deep import
+ * `chakra-react-select/dist/types/types`. That path is not listed in
+ * `chakra-react-select`'s package `exports` map, so it only resolves under the
+ * legacy `moduleResolution: "node"` and breaks under `"bundler"`/`node16`/
+ * `nodenext` (TypeScript 7).
+ */
+export type SelectVariant =
+  | 'outline'
+  | 'filled'
+  | 'flushed'
+  | 'unstyled'
+  | (string & {})
+
+/**
+ * The chakra-specific props that `chakra-react-select` adds to `react-select`'s
+ * `Props` via module augmentation.
+ *
+ * We redeclare them explicitly here instead of relying on that augmentation.
+ * The augmentation targets react-select's unbundled declaration path
+ * (`react-select/dist/declarations/src/Select`), which only merges under
+ * `moduleResolution: "node"`. Under `"bundler"`/`node16`/`nodenext` (TS7),
+ * react-select resolves to its bundled declarations, the augmentation never
+ * merges, and every chakra prop (`chakraStyles`, `colorScheme`, ...) silently
+ * disappears from consumers' types. Declaring them here keeps `@northlight/ui`'s
+ * select types self-contained and resolution-independent.
+ *
+ * Note: `size` is intentionally omitted — every consuming interface declares its
+ * own narrower `size` prop.
+ */
+export interface ChakraReactSelectExtraProps<
+  Option,
+  IsMulti extends boolean,
+  Group extends GroupBase<Option> = GroupBase<Option>
+> {
+  /** Style transformation methods for each rendered chakra-react-select component. */
+  chakraStyles?: ChakraStylesConfig<Option, IsMulti, Group>
+  /** Chakra theme color key that styles the `MultiValue` tags. */
+  colorScheme?: string
+  /** Style the dropdown indicator like Chakra UI's native `Select`. */
+  useBasicStyles?: boolean
+  /** Main style variant forwarded to the underlying chakra `Input`. */
+  variant?: SelectVariant
+  /** Variant forwarded to the `MultiValue` chakra `Tag`. */
+  tagVariant?: TagVariant
+  /** Highlight the selected option with a solid color or a check mark. */
+  selectedOptionStyle?: SelectedOptionStyle
+  /** Color scheme used when `selectedOptionStyle="color"`. */
+  selectedOptionColorScheme?: string
+  /** @deprecated Replaced by `selectedOptionColorScheme`. */
+  selectedOptionColor?: string
+  /** Border color of the `Control` when the select is focused. */
+  focusBorderColor?: string
+  /** Border color of the `Control` when `isInvalid` is passed. */
+  errorBorderColor?: string
+  /** Style the input with the invalid border color. */
+  isInvalid?: boolean
+  /** Render the control as read-only. */
+  isReadOnly?: boolean
+  /** Mark the control as required (adds the `FormLabel` indicator + `aria-required`). */
+  isRequired?: boolean
+  /** Keep group headers stuck to the top while their group is in view. */
+  hasStickyGroupHeaders?: boolean
+}

--- a/framework/lib/types/index.ts
+++ b/framework/lib/types/index.ts
@@ -1,2 +1,3 @@
 export * from './color'
 export * from './input-field'
+export * from './chakra-react-select'


### PR DESCRIPTION
@northlight/ui's SelectProps relied on chakra-react-select's module augmentation of react-select's `Props`. That augmentation targets react-select's unbundled declaration path
(react-select/dist/declarations/src/Select), which only merges under moduleResolution: "node". Under "bundler"/node16/nodenext (TS7), react-select resolves to its bundled declarations, the augmentation never merges, and every chakra prop (chakraStyles, colorScheme, size, variant, selectedOptionStyle, ...) silently vanished from consumers' types — TS2322 on those props and TS7006 on the chakraStyles callbacks.

Make the select-family types self-contained instead of depending on the fragile augmentation: add a ChakraReactSelectExtraProps interface (and a local SelectVariant type) that re-declares the chakra additions, using only root-exported chakra-react-select types (ChakraStylesConfig, TagVariant, SelectedOptionStyle) so it resolves identically under every moduleResolution. Wire it into Select, SearchBar, and CreatableSelectDropdown; the latter also dropped its deep `chakra-react-select/dist/types/types` import (not in the package exports map, so it too broke under bundler).

Verified a `<Select chakraStyles size colorScheme variant ... />` usage type-checks with no TS2322/TS7006 under moduleResolution bundler, nodenext, and node, against the built dist types.