### PR TITLE
fix(select): restore size prop on CreatableSelectDropdown

### DIFF
--- a/framework/lib/types/chakra-react-select/index.ts
+++ b/framework/lib/types/chakra-react-select/index.ts
@@ -1,9 +1,24 @@
+import type { ResponsiveObject } from '@chakra-ui/system'
 import type {
   ChakraStylesConfig,
   GroupBase,
   SelectedOptionStyle,
+  Size,
   TagVariant,
 } from 'chakra-react-select'
+
+/**
+ * The `size` value accepted by the underlying chakra `Input`/`Select`.
+ *
+ * Structurally identical to `chakra-react-select`'s internal `SizeProp`
+ * (`Size | ResponsiveObject<Size> | Size[]`), reconstructed here from the
+ * root-exported `Size` because `SizeProp` itself is not exported from the
+ * package entry. Keeping it identical to the type the removed module
+ * augmentation put on react-select's `Props` avoids a "cannot simultaneously
+ * extend" (TS2320) conflict for interfaces (`SelectProps`, `SearchBarProps`)
+ * that still inherit `size` through their `Props` chain.
+ */
+export type SelectSize = Size | ResponsiveObject<Size> | Size[]
 
 /**
  * The `variant` value forwarded to the underlying chakra `Input`/`Select`.
@@ -35,14 +50,17 @@ export type SelectVariant =
  * disappears from consumers' types. Declaring them here keeps `@northlight/ui`'s
  * select types self-contained and resolution-independent.
  *
- * Note: `size` is intentionally omitted — every consuming interface declares its
- * own narrower `size` prop.
  */
 export interface ChakraReactSelectExtraProps<
   Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > {
+  /**
+   * The size of the base control; matches the sizes of the chakra `Input`
+   * component (`sm` | `md` | `lg`). A responsive array/object may also be passed.
+   */
+  size?: SelectSize
   /** Style transformation methods for each rendered chakra-react-select component. */
   chakraStyles?: ChakraStylesConfig<Option, IsMulti, Group>
   /** Chakra theme color key that styles the `MultiValue` tags. */


### PR DESCRIPTION
The 2.44.5 bundler/TS7 fix replaced chakra-react-select's module augmentation with an explicit ChakraReactSelectExtraProps interface, but that interface omitted `size`. SelectProps/SearchBarProps still inherit `size` through their react-select `Props` chain, so they were unaffected; CreatableSelectDropdownProps gets its chakra props ONLY from ChakraReactSelectExtraProps, so `<CreatableSelectDropdown size="sm" />` regressed to TS2322 under moduleResolution: bundler (worked in 2.44.0 when the augmentation carried `size` onto everything).

Add `size` to ChakraReactSelectExtraProps using a reconstructed `SelectSize` (Size | ResponsiveObject<Size> | Size[]) that is structurally identical to chakra-react-select's own (non-exported) `SizeProp`, so it stays consistent across Select, SearchBar, CreatableSelectDropdown and avoids a TS2320 conflict on the interfaces that also inherit `size` via their Props chain.

Diffed the full old-augmentation prop set against the new extras: `size` was the only genuinely-dropped prop. `styles` and `theme` are core react-select props (only re-declared as deprecated by the augmentation), so they remain available via the Props/CreatableProps chain under bundler.

Verified <CreatableSelectDropdown size="sm" /> (and responsive size={{ base, md }}) type-checks clean under moduleResolution bundler and node, Select/SearchBar size unchanged, and an invalid size still errors.